### PR TITLE
Fix ship log astro object ids

### DIFF
--- a/planets/ShipLogs/BrittleHollow_Body.xml
+++ b/planets/ShipLogs/BrittleHollow_Body.xml
@@ -1,5 +1,5 @@
 <AstroObjectEntry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/shiplog_schema.xsd">
-  <ID>BRITTLEHOLLOW_BODY</ID>
+  <ID>BRITTLE_HOLLOW</ID>
 
   <Entry>
     <ID>SOLANUM_BH</ID>

--- a/planets/ShipLogs/CaveTwin_Body.xml
+++ b/planets/ShipLogs/CaveTwin_Body.xml
@@ -1,5 +1,5 @@
 <AstroObjectEntry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/shiplog_schema.xsd">
-  <ID>RINGWORLD_BODY</ID>
+  <ID>CAVE_TWIN</ID>
 
   <Entry>
     <ID>SOLANUM_ET</ID>

--- a/planets/ShipLogs/RingWorld.xml
+++ b/planets/ShipLogs/RingWorld.xml
@@ -1,5 +1,5 @@
 <AstroObjectEntry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/shiplog_schema.xsd">
-  <ID>RINGWORLD_BODY</ID>
+  <ID>INVISIBLE_PLANET</ID>
 
   <Entry>
     <ID>VISION_TORCH_ENTRY</ID>


### PR DESCRIPTION
A couple of astro object ids weren't the ones that the games use (`BRITTLEHOLLOW_BODY`  should be `BRITTLE_HOLLOW`  and `RINGWORLD_BODY` should be `INVISIBLE_PLANET`). That made the entries defined in the XML files not show up in Map Mode. Also, the Ember Twin file had `RINGWORLD_BODY` instead of the correct one `CAVE_TWIN`.