### PR TITLE
fix: untranslated ship log title

### DIFF
--- a/translations/chinese_simple.json
+++ b/translations/chinese_simple.json
@@ -14,7 +14,7 @@
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
           "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "距离循环结束传输前还有<![CDATA[<TimeMinutesRemaining>]]>分钟。",
           "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "警告！移除核心将会中止 <![CDATA[<color=orange>灰烬双星计划</color>]]>.",
-
+  
           // Quantum Moon
           "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "所莱内姆: 好奇怪，我在哪里？我现在能看见星星了。看上去，我得在天上找到答案。",
           "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "所莱内姆: 很奇怪，我感觉不到我死了。也许这是我过去的不稳定态。这个地方很眼熟，像木炉...",
@@ -29,7 +29,7 @@
           "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "所莱内姆: 不过，来自另一个恒星系统的外星站居民有关键性的知识。他们有能更深入理解<![CDATA[<color=lightblue>眼</color>]]>的科技。我猜测，他们根据预言内容认为<![CDATA[<color=lightblue>眼</color>]]>是危险的。然而他们的理解可能是错的。",
           "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "所莱内姆: 我们该如何利用这些关于<![CDATA[<color=lightblue>眼</color>]]>的知识？我想了解它，想找到它，但我不知道如何到达它在的那个地方。",
           "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "所莱内姆: 我操作失误了吗？难道那尊记忆雕像已经激活了？如果是激活状态，它会将数据传输到<![CDATA[<color=orange>灰烬双星计划</color>]]>里...我去那看看。",
-          // Recorder ATP
+          // Recorder ATP 
           "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "所莱内姆: 我猜你见过这个？太阳即将消亡...但你和其中一尊雕像匹配了？现在我明白了。你知道<![CDATA[<color=lightblue>深巨星</color>]]>上匹配过的另一个人吗？",
           "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "所莱内姆: 真可惜。如果我能学会你的语言，我会问很多问题。",
           "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "所莱内姆: 现在我和你一样，也与雕像连接在一起。我站在那边那尊雕像正前方，然后它睁开了眼睛。",
@@ -60,14 +60,14 @@
           "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "所莱内姆: 一想到这种可能性就令人兴奋。但我并不害怕。其实在经历了这一切后，我已经无所畏惧了。这些只不过是宇宙生存的法则。",
           "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "所莱内姆: 两位有意识的观察者开始了通向命运的旅程。我能感觉到不确定性正在飞快地增长。自从我离开<![CDATA[<color=lightblue>量子卫星</color>]]>以来从未有如此强烈的感觉。",
           "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "所莱内姆: 一旦出发，就没有回头路可走了。无论发生什么我都准备好了，朋友。决定权在你。",
-
+  
           // EYE SCENE
           "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "所莱内姆: 两个有意识的观察者进入了宇宙之眼。我接受你的选择。",
           "SOLANUM: Would you try to enter it?": "所莱内姆: 你想试着进去吗？",
           "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "所莱内姆，最后一个活着的挪麦人，由于悖论而获得了量子意识。她和我一起进入了眼。",
           "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "我到了<![CDATA[<color=lightblue>背阴城</color>]]>。我在这里遇到了莱阿维，拉米，塔格特，还有其他挪麦人。也许我们的旅程已经走到了尽头。",
-
-
+  
+  
           // Ernesto Quest
           // Slate note
           "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "我去... 去... 采<![CDATA[<i>蘑菇</i>]]>了。别占了我的位置！我很快就会回来。去天文台拿<![CDATA[<color=orange>新发射密码</color>]]> ，霍恩费斯一分钟前把它改了。",
@@ -99,16 +99,16 @@
           "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "嗯... 这里似乎很适合放投影火把！如果需要的话，我可以把它放在这。"
       },
       "UIDictionary": {
-
+  
           "Quantum Consciousness": "量子意识",
           "Solanum": "所莱内姆",
           "GloamingGalaxy": "暮色银河",
           "THE_VISION_NEW_LAUNCH_CODES": "新的发射密码: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-
+  
           "THE_VISION_TO_BE_CONTINUED": "你和所莱内姆逃离了超新星的范围，在黑石星系遇到了其他挪麦人。\n你们一起见证了繁星消散，宇宙逝去。", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
           "THE_VISION_POPUP": "感谢您下载«The Vision»！检查您的航天日志来开启一段新的故事。" // Thank you for downloading «The Vision»! Check your ship logs to start new story. If you’re having trouble with viewing the vision, please try lower your game resolution.
-
-
+  
+  
       },
       "ShipLogDictionary": {
           // Brittle Hollow
@@ -117,13 +117,13 @@
           "I can hear Solanum's signal coming from Brittle Hollow.": "我可以听见所莱内姆的信号从碎空星传来。",
           "I found Solanum in the School.": "我在学校里发现了所莱内姆。",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "所莱内姆说这里是她上学的地方。她也提到黑洞在过去比较小。她带了一枚重力水晶以防跌落。",
-
+  
           // CaveTwin_Body
           "Solanum in the Sunless City": "背阴城中的所莱内姆",
           "I can hear Solanum's signal coming from the Sunless City.": "我可以听见所莱内姆的信号从背阴城传来。",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "我在背阴城内找到了所莱内姆。她呆在位于眼祭坛区的家里。",
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "看到变成了废墟的背阴城，所莱内姆十分悲伤。她向我讲述了她的童年。",
-
+  
           // DB_VesselBody
           "Solanum on the Vessel": "飞船内的所莱内姆",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "所莱内姆想要尝试抵达飞船。她有可能进入黑棘星内部吗？",
@@ -132,13 +132,13 @@
           "Gloaming Galaxy, Blackrock coordinates hologram": "暮色银河，黑石星系坐标的全息图",
           "New coordinates": "新坐标",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "我找到了去暮色银河的坐标，我们可以使用灰烬双星计划中的跃迁核心前往那里。但是一旦选择就没有回头路了。我真的做好准备了吗？",
-
+  
           // Giants Deep
           "Solanum on Giant's Deep": "深巨星上的所莱内姆",
           "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "所莱内姆想看看深巨星，但她可能也会呆在木炉星上。",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "我看到所莱内姆正在观察航天日志。我从未见过挪麦电脑发出这样的绿色光芒。她正在访问主电脑来知道究竟过去了多久。",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "所莱内姆对眼和外星站居民看到的预言陷入了沉思。她也注意到了一尊还在活动的记忆雕像。",
-
+  
           // Quantum Moon
           "Solanum on Quantum Moon": "量子卫星上的所莱内姆",
           "What if..?": "假如..?",
@@ -149,12 +149,12 @@
           "Solanum left some text near her body": "所莱内姆在她的尸体旁留下了一些文字",
           "There are some new inscriptions left very recently": "这里有不久前留下的新的铭文",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "所莱内姆的信息在提到木炉星时戛然而止。",
-
+  
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "故障实验室中的火把视野",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "我确信在故障实验室的某处有一支火把视野。我想知道它是否还有用。",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "我找到了那支火把视野。即使在没有氧气的太空中，它的火焰依旧跳动。",
-
+  
           // Timber Hearth
           "Solanum on Timber Hearth": "木炉星上的所莱内姆",
           "Is Solanum on Timber Hearth?": "所莱内姆会在木炉星上吗？",
@@ -162,7 +162,7 @@
           "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "当所莱内姆提起木炉星时，文字被打断了。也许她在那儿？",
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "所莱内姆不知怎么出现在木炉星的村庄附近。看起来她正在观察哈斯人。",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "所莱内姆一想到木炉星，就出现在那里。她想了解更多关于深巨星探测器跟踪模块的事。",
-
+  
           // Quantum Consciousness
           "Quantum Consciousness": "量子意识",
           "I've discovered strange frequency called Quantum Consciousness.": "我发现了一种叫做量子意识的奇怪频率。",
@@ -170,19 +170,19 @@
           "Quantum Consciousness has a strong recognizable signal and it sounds similar to the Quantum Fluctuations. In fact, the signal is very strong. It can be heard even without signalscope.": "量子意识有强烈的可识别信号，听起来和量子波动很像。事实上，这个信号强到即使不装备信号镜也能听见。",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "量子意识的另一个显著特征是持有者头部附近出现粒子。注: 似乎其他量子法则对量子意识不适用。",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "由于未知原因，量子意识的持有者具有同时存在于多个地方的能力。据所莱内姆所说，她能想象一个特定地点，然后出现在那里。也许她只能出现在她知道的地方。",
-
-
+  
+  
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "灰烬双星计划中的所莱内姆",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "所莱内姆想查看时间循环的控制面板，我们可以在灰烬双星计划里找到她。",
           "Solanum is already here. She observing the time loop ring's logs.": "所莱内姆已经到了，她正在查看时间循环的日志。",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": "既然现在她知道了时间循环，那么很快太阳就会超新星化。所莱内姆想去挪麦飞船，但她也想重游她童年的地方。我可以去挪麦飞船或其他地方去找找她。",
-
+  
           "Paired Statue": "已匹配的雕像",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "所莱内姆刚刚恰好经过了灰烬双星计划中未被匹配的回忆雕像。现在她也被困进时间循环了。",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "上一个循环，所莱内姆不确定时间循环是如何工作的，但在这个循环中所莱内姆似乎已经了解了一切。她现在想去挪麦飞船。",
-
-          // Ernesto Quest
+  
+          // Ernesto Quest    
           "Where is Ernesto?": "厄内斯托在哪？",
           "Seriously, how could an anglerfish just disappear?": "老实说，那安康鱼怎么可能自己凭空消失。",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "霍恩菲斯说博物馆里那只叫«厄内斯托»的安康鱼不见了。",
@@ -190,6 +190,6 @@
           "I found Ernesto": "我找到厄内斯托了",
           "I found Slate with Ernesto. He's cooking him on campfire.": "我在斯雷特那里找到了厄内斯托，他把厄内斯托夹在篝火上烤了。",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "斯雷特受够了烤棉花糖，所以他决定把厄内斯托料理了，大概需要30分钟就可以完成。看来不需要阻止他了，在他完事前循环会先到来。"
-
+  
       }
   }

--- a/translations/chinese_simple.json
+++ b/translations/chinese_simple.json
@@ -14,7 +14,7 @@
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
           "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "距离循环结束传输前还有<![CDATA[<TimeMinutesRemaining>]]>分钟。",
           "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "警告！移除核心将会中止 <![CDATA[<color=orange>灰烬双星计划</color>]]>.",
-  
+
           // Quantum Moon
           "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "所莱内姆: 好奇怪，我在哪里？我现在能看见星星了。看上去，我得在天上找到答案。",
           "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "所莱内姆: 很奇怪，我感觉不到我死了。也许这是我过去的不稳定态。这个地方很眼熟，像木炉...",
@@ -29,7 +29,7 @@
           "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "所莱内姆: 不过，来自另一个恒星系统的外星站居民有关键性的知识。他们有能更深入理解<![CDATA[<color=lightblue>眼</color>]]>的科技。我猜测，他们根据预言内容认为<![CDATA[<color=lightblue>眼</color>]]>是危险的。然而他们的理解可能是错的。",
           "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "所莱内姆: 我们该如何利用这些关于<![CDATA[<color=lightblue>眼</color>]]>的知识？我想了解它，想找到它，但我不知道如何到达它在的那个地方。",
           "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "所莱内姆: 我操作失误了吗？难道那尊记忆雕像已经激活了？如果是激活状态，它会将数据传输到<![CDATA[<color=orange>灰烬双星计划</color>]]>里...我去那看看。",
-          // Recorder ATP 
+          // Recorder ATP
           "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "所莱内姆: 我猜你见过这个？太阳即将消亡...但你和其中一尊雕像匹配了？现在我明白了。你知道<![CDATA[<color=lightblue>深巨星</color>]]>上匹配过的另一个人吗？",
           "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "所莱内姆: 真可惜。如果我能学会你的语言，我会问很多问题。",
           "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "所莱内姆: 现在我和你一样，也与雕像连接在一起。我站在那边那尊雕像正前方，然后它睁开了眼睛。",
@@ -60,14 +60,14 @@
           "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "所莱内姆: 一想到这种可能性就令人兴奋。但我并不害怕。其实在经历了这一切后，我已经无所畏惧了。这些只不过是宇宙生存的法则。",
           "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "所莱内姆: 两位有意识的观察者开始了通向命运的旅程。我能感觉到不确定性正在飞快地增长。自从我离开<![CDATA[<color=lightblue>量子卫星</color>]]>以来从未有如此强烈的感觉。",
           "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "所莱内姆: 一旦出发，就没有回头路可走了。无论发生什么我都准备好了，朋友。决定权在你。",
-  
+
           // EYE SCENE
           "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "所莱内姆: 两个有意识的观察者进入了宇宙之眼。我接受你的选择。",
           "SOLANUM: Would you try to enter it?": "所莱内姆: 你想试着进去吗？",
           "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "所莱内姆，最后一个活着的挪麦人，由于悖论而获得了量子意识。她和我一起进入了眼。",
           "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "我到了<![CDATA[<color=lightblue>背阴城</color>]]>。我在这里遇到了莱阿维，拉米，塔格特，还有其他挪麦人。也许我们的旅程已经走到了尽头。",
-  
-  
+
+
           // Ernesto Quest
           // Slate note
           "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "我去... 去... 采<![CDATA[<i>蘑菇</i>]]>了。别占了我的位置！我很快就会回来。去天文台拿<![CDATA[<color=orange>新发射密码</color>]]> ，霍恩费斯一分钟前把它改了。",
@@ -99,16 +99,16 @@
           "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "嗯... 这里似乎很适合放投影火把！如果需要的话，我可以把它放在这。"
       },
       "UIDictionary": {
-  
+
           "Quantum Consciousness": "量子意识",
           "Solanum": "所莱内姆",
           "GloamingGalaxy": "暮色银河",
           "THE_VISION_NEW_LAUNCH_CODES": "新的发射密码: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-  
+
           "THE_VISION_TO_BE_CONTINUED": "你和所莱内姆逃离了超新星的范围，在黑石星系遇到了其他挪麦人。\n你们一起见证了繁星消散，宇宙逝去。", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
           "THE_VISION_POPUP": "感谢您下载«The Vision»！检查您的航天日志来开启一段新的故事。" // Thank you for downloading «The Vision»! Check your ship logs to start new story. If you’re having trouble with viewing the vision, please try lower your game resolution.
-  
-  
+
+
       },
       "ShipLogDictionary": {
           // Brittle Hollow
@@ -117,13 +117,13 @@
           "I can hear Solanum's signal coming from Brittle Hollow.": "我可以听见所莱内姆的信号从碎空星传来。",
           "I found Solanum in the School.": "我在学校里发现了所莱内姆。",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "所莱内姆说这里是她上学的地方。她也提到黑洞在过去比较小。她带了一枚重力水晶以防跌落。",
-  
+
           // CaveTwin_Body
           "Solanum in the Sunless City": "背阴城中的所莱内姆",
           "I can hear Solanum's signal coming from the Sunless City.": "我可以听见所莱内姆的信号从背阴城传来。",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "我在背阴城内找到了所莱内姆。她呆在位于眼祭坛区的家里。",
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "看到变成了废墟的背阴城，所莱内姆十分悲伤。她向我讲述了她的童年。",
-  
+
           // DB_VesselBody
           "Solanum on the Vessel": "飞船内的所莱内姆",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "所莱内姆想要尝试抵达飞船。她有可能进入黑棘星内部吗？",
@@ -132,13 +132,13 @@
           "Gloaming Galaxy, Blackrock coordinates hologram": "暮色银河，黑石星系坐标的全息图",
           "New coordinates": "新坐标",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "我找到了去暮色银河的坐标，我们可以使用灰烬双星计划中的跃迁核心前往那里。但是一旦选择就没有回头路了。我真的做好准备了吗？",
-  
+
           // Giants Deep
           "Solanum on Giant's Deep": "深巨星上的所莱内姆",
           "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "所莱内姆想看看深巨星，但她可能也会呆在木炉星上。",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "我看到所莱内姆正在观察航天日志。我从未见过挪麦电脑发出这样的绿色光芒。她正在访问主电脑来知道究竟过去了多久。",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "所莱内姆对眼和外星站居民看到的预言陷入了沉思。她也注意到了一尊还在活动的记忆雕像。",
-  
+
           // Quantum Moon
           "Solanum on Quantum Moon": "量子卫星上的所莱内姆",
           "What if..?": "假如..?",
@@ -149,20 +149,20 @@
           "Solanum left some text near her body": "所莱内姆在她的尸体旁留下了一些文字",
           "There are some new inscriptions left very recently": "这里有不久前留下的新的铭文",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "所莱内姆的信息在提到木炉星时戛然而止。",
-  
+
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "故障实验室中的火把视野",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "我确信在故障实验室的某处有一支火把视野。我想知道它是否还有用。",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "我找到了那支火把视野。即使在没有氧气的太空中，它的火焰依旧跳动。",
-  
+
           // Timber Hearth
           "Solanum on Timber Hearth": "木炉星上的所莱内姆",
           "Is Solanum on Timber Hearth?": "所莱内姆会在木炉星上吗？",
-          "New quantum frequency": "新的量子频率",
+          "New quantum frequency?": "新的量子频率？",
           "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "当所莱内姆提起木炉星时，文字被打断了。也许她在那儿？",
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "所莱内姆不知怎么出现在木炉星的村庄附近。看起来她正在观察哈斯人。",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "所莱内姆一想到木炉星，就出现在那里。她想了解更多关于深巨星探测器跟踪模块的事。",
-  
+
           // Quantum Consciousness
           "Quantum Consciousness": "量子意识",
           "I've discovered strange frequency called Quantum Consciousness.": "我发现了一种叫做量子意识的奇怪频率。",
@@ -170,19 +170,19 @@
           "Quantum Consciousness has a strong recognizable signal and it sounds similar to the Quantum Fluctuations. In fact, the signal is very strong. It can be heard even without signalscope.": "量子意识有强烈的可识别信号，听起来和量子波动很像。事实上，这个信号强到即使不装备信号镜也能听见。",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "量子意识的另一个显著特征是持有者头部附近出现粒子。注: 似乎其他量子法则对量子意识不适用。",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "由于未知原因，量子意识的持有者具有同时存在于多个地方的能力。据所莱内姆所说，她能想象一个特定地点，然后出现在那里。也许她只能出现在她知道的地方。",
-  
-  
+
+
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "灰烬双星计划中的所莱内姆",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "所莱内姆想查看时间循环的控制面板，我们可以在灰烬双星计划里找到她。",
           "Solanum is already here. She observing the time loop ring's logs.": "所莱内姆已经到了，她正在查看时间循环的日志。",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": "既然现在她知道了时间循环，那么很快太阳就会超新星化。所莱内姆想去挪麦飞船，但她也想重游她童年的地方。我可以去挪麦飞船或其他地方去找找她。",
-  
+
           "Paired Statue": "已匹配的雕像",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "所莱内姆刚刚恰好经过了灰烬双星计划中未被匹配的回忆雕像。现在她也被困进时间循环了。",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "上一个循环，所莱内姆不确定时间循环是如何工作的，但在这个循环中所莱内姆似乎已经了解了一切。她现在想去挪麦飞船。",
-  
-          // Ernesto Quest    
+
+          // Ernesto Quest
           "Where is Ernesto?": "厄内斯托在哪？",
           "Seriously, how could an anglerfish just disappear?": "老实说，那安康鱼怎么可能自己凭空消失。",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "霍恩菲斯说博物馆里那只叫«厄内斯托»的安康鱼不见了。",
@@ -190,6 +190,6 @@
           "I found Ernesto": "我找到厄内斯托了",
           "I found Slate with Ernesto. He's cooking him on campfire.": "我在斯雷特那里找到了厄内斯托，他把厄内斯托夹在篝火上烤了。",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "斯雷特受够了烤棉花糖，所以他决定把厄内斯托料理了，大概需要30分钟就可以完成。看来不需要阻止他了，在他完事前循环会先到来。"
-  
+
       }
   }

--- a/translations/english.json
+++ b/translations/english.json
@@ -18,21 +18,21 @@
     "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION.",
     "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.",
 
-    // Quantum Moon
+    // Quantum Moon	
     "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.",
     "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...",
-    // Recorder TH
+    // Recorder TH	
     "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.",
     "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.",
     "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.",
     "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.",
     "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Probe Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.",
-    // Recorder GD
+    // Recorder GD	
     "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the Universe</color>]]>. I wish my clan could see this.",
     "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Still, the strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.",
     "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ",
     "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>... I'll take a look at it.",
-    // Recorder ATP
+    // Recorder ATP 	
     "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant's Deep</color>]]>?",
     "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.",
     "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Perhaps, now I am linked to the statue in the same way as you. I ended up right in front of that nearby statue and it opened its eyes.",
@@ -40,21 +40,21 @@
     "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit the <![CDATA[<color=lightblue>places from my childhood</color>]]> first, before departing.",
     "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.",
     "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: From your vision, I now know <![CDATA[<color=orange>the Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?",
-    // Recorder ATP 2
+    // Recorder ATP 2	
     "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.",
     "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz said: <![CDATA[<i>\"Sending memories back in time and going back in time physically are two different actions\"</i>]]>.",
     "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.",
-    // Recorder BH
+    // Recorder BH	
     "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.",
     "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: As a student, I would imagine the universe ending. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.",
     "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.",
     "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.",
-    // Recorder ET
+    // Recorder ET	
     "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: I spent my childhood here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.",
     "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.",
     "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: It's unsafe here, I think. I can hear the sand rising.",
     "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.",
-    // Recorder DB
+    // Recorder DB	
     "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.",
     "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe the disappearance of Escall's Vessel was a myth.",
     "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...",
@@ -66,7 +66,7 @@
 
 
 
-    // EYE SCENE
+    // EYE SCENE	
     "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Two conscious observers have reached the Eye of the Universe. I accept your decision.",
     "SOLANUM: Would you try to enter it?": "SOLANUM: Would you try to enter it?",
     "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.",
@@ -134,7 +134,7 @@
         "Solanum in the Sunless City": "Solanum in the Sunless City",
         "I can hear Solanum's signal coming from the Sunless City.": "I can hear Solanum's signal coming from the Sunless City.",
         "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.",
-        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
+        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
         "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "She feels sad seeing the Sunless City in ruins. Solanum told me a little about her childhood.",
 
 
@@ -213,7 +213,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems as if she understands everything, and wants to go to the Vessel.",
 
 
-        // Ernesto Quest
+        // Ernesto Quest        
         "Where is Ernesto?": "Where is Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "Seriously, how could an anglerfish just disappear?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Hornfels said that the anglerfish \"Ernesto\" disappeared from its exhibit.",

--- a/translations/english.json
+++ b/translations/english.json
@@ -18,21 +18,21 @@
     "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION.",
     "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.",
 
-    // Quantum Moon	
+    // Quantum Moon
     "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.",
     "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...",
-    // Recorder TH	
+    // Recorder TH
     "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.",
     "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.",
     "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.",
     "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.",
     "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Probe Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.",
-    // Recorder GD	
+    // Recorder GD
     "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the Universe</color>]]>. I wish my clan could see this.",
     "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Still, the strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.",
     "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ",
     "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>... I'll take a look at it.",
-    // Recorder ATP 	
+    // Recorder ATP
     "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant's Deep</color>]]>?",
     "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.",
     "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Perhaps, now I am linked to the statue in the same way as you. I ended up right in front of that nearby statue and it opened its eyes.",
@@ -40,21 +40,21 @@
     "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit the <![CDATA[<color=lightblue>places from my childhood</color>]]> first, before departing.",
     "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.",
     "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: From your vision, I now know <![CDATA[<color=orange>the Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?",
-    // Recorder ATP 2	
+    // Recorder ATP 2
     "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.",
     "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz said: <![CDATA[<i>\"Sending memories back in time and going back in time physically are two different actions\"</i>]]>.",
     "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.",
-    // Recorder BH	
+    // Recorder BH
     "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.",
     "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: As a student, I would imagine the universe ending. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.",
     "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.",
     "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.",
-    // Recorder ET	
+    // Recorder ET
     "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: I spent my childhood here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.",
     "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.",
     "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: It's unsafe here, I think. I can hear the sand rising.",
     "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.",
-    // Recorder DB	
+    // Recorder DB
     "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.",
     "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe the disappearance of Escall's Vessel was a myth.",
     "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...",
@@ -66,7 +66,7 @@
 
 
 
-    // EYE SCENE	
+    // EYE SCENE
     "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Two conscious observers have reached the Eye of the Universe. I accept your decision.",
     "SOLANUM: Would you try to enter it?": "SOLANUM: Would you try to enter it?",
     "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.",
@@ -134,7 +134,7 @@
         "Solanum in the Sunless City": "Solanum in the Sunless City",
         "I can hear Solanum's signal coming from the Sunless City.": "I can hear Solanum's signal coming from the Sunless City.",
         "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.",
-        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
+        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
         "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "She feels sad seeing the Sunless City in ruins. Solanum told me a little about her childhood.",
 
 
@@ -180,7 +180,7 @@
         // Timber Hearth
         "Solanum on Timber Hearth": "Solanum on Timber Hearth",
         "Is Solanum on Timber Hearth?": "Is Solanum on Timber Hearth?",
-        "New quantum frequency": "New quantum frequency",
+        "New quantum frequency?": "New quantum frequency?",
         "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?",
         "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.",
         //"According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.": "According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.",
@@ -213,7 +213,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems as if she understands everything, and wants to go to the Vessel.",
 
 
-        // Ernesto Quest        
+        // Ernesto Quest
         "Where is Ernesto?": "Where is Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "Seriously, how could an anglerfish just disappear?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Hornfels said that the anglerfish \"Ernesto\" disappeared from its exhibit.",

--- a/translations/french.json
+++ b/translations/french.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/translation_schema.json",
       "DialogueDictionary": {
-  
+
           // Hint: use «» instead of "".
           // Computer GD
           "MAIN COMPUTER: Log access granted, SOLANUM. USER REQUEST: «Last access granted». Calculating...": "ORDINATEUR PRINCIPAL: accès au journal accordé, SOLANUM. \nREQUETE UTILISATEUR: «Dernier accès accorder». calcul en cours...", // use \n here to enter new line
           "MAIN COMPUTER: Last access granted 281,042 years ago. USER = Mallow.": "ORDINATEUR PRINCIPAL: Dernier accès accorder il y a 281,042 années. \nUTILISATEUR = Mallow.", // and here
           "Visualizing progress. Deep space anomaly matching all known criteria for the <![CDATA[<color=lightblue>Eye of the universe</color>]]> has been found.": "Visualisation du progrès. Une anomalie dans l'espace lointain correspondant à tous les critères connus pour l'<![CDATA[<color=lightblue>Œil de l'univers</color>]]> a été découverte.",
-  
+
           // Computer ATP
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutes>]]> MINUTES, <![CDATA[<TimeSeconds>]]> SECONDS AGO: Data received from previous cycles."
           "ASH TWIN PROJECT: Receiving data cycle set up to <![CDATA[<color=orange>22 MINUTES</color>]]>.": "IL Y A <![CDATA[<TimeMinutes>]]> MINUTES ET <![CDATA[<TimeSeconds>]]> SECONDES: Données reçues des cycles précédents.",
@@ -16,7 +16,7 @@
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
           "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTES AVANT LA TRANSMISSION DE FIN DE CYCLE.",
           "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "ATTENTION: Retirer le générateur désactivera le <![CDATA[<color=orange>Projet Sablière noir</color>]]>.",
-  
+
           // Quantum Moon
           "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM : C'est étrange. Où suis-je ? Je vois des étoiles maintenant. Il est probable que je trouve les réponses dans le ciel.",
           "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM : C'est étrange, je ne me sens pas morte. C'est peut-être mon incertitude passée. Cet endroit me semble familier. Je suppose que c'est un état de Âtrebo...",
@@ -31,7 +31,7 @@
           "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM : Pourtant, des étrangers venus d'un autre système stellaire avaient des connaissances importantes. Ils avaient une technologie permettant de mieux comprendre l'<![CDATA[<color=lightblue>Oeil</color>]]>. J'ai une hypothèse que l'<![CDATA[<color=lightblue>Oeil</color>]]> est dangereux, basée sur leur vision. Cependant, leur interprétation pourrait être erronée.",
           "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM : Que faisons-nous de ces connaissances sur l' < ![CDATA[<color=lightblue>Eye</color>]]> ? Je veux en apprendre davantage à son sujet, et je veux le trouver - mais je ne sais pas comment l'atteindre.",
           "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM : Est-ce que je me trompe ? Est-ce que cette Statue mnémonique est active ? Dans cet état actif, elle devrait transmettre des données au <!CDATA[<color=orange>Projet Sablière noir</color>]>... Je vais y jeter un coup d'oeil.",
-          // Recorder ATP 
+          // Recorder ATP
           "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM : Je suppose que vous avez vu ceci ? Notre soleil est en train de mourir... mais vous êtes liés à l'une des statues ? Maintenant je comprends. Savez-vous qui d'autre est jumelé la statue de < ![CDATA[<color=lightblue>Léviathe</color>]]> ?",
           "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM : C'est regrettable. Il y a beaucoup de questions que je voudrais vous poser si je pouvais comprendre votre langue.",
           "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM : Peut-être, maintenant je suis lié à la Statue de la même façon que vous. Je me suis retrouvé juste en face de cette statue toute proche et elle a ouvert les yeux.",
@@ -62,17 +62,17 @@
           "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "SOLANUM : Penser à une telle possibilité est excitant. Mais je n'en ai pas peur. En fait, après tout ce qui s'est passé, je n'ai aucune crainte. Ce sont simplement les lois par lesquelles l'univers vie.",
           "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "SOLANUM: Deux observateurs conscients entament un voyage vers le destin. Je sens que l'incertitude grandit énormément. Elle n'a pas été aussi forte depuis que j'ai quitté la < ![CDATA[<color=lightblue>Lune Quantique</color>]]>.",
           "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "SOLANUM : Il n'y aura pas de retour en arrière. Je suis prêt pour ce qui va suivre, mon ami. La décision vous appartient.",
-  
+
           // EYE SCENE
           "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM : Deux observateurs conscients ont atteint l'Œil de l'univers. J'accepte votre décision.",
           "SOLANUM: Would you try to enter it?": "SOLANUM : Essayeriez-vous d'y entrer ?",
           "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, la dernière Nomai en vie, a acquis la Conscience Quantique à la suite d'un paradoxe. Elle est entrée dans l'Oeil avec moi.",
           "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "J'étais dans la < ![CDATA[<color=lightblue>Cité Obscure</color>]]>. J'y ai rencontré d'autres Nomai : Laevi, Tage, Lami et d'autres. Peut-être que notre voyage a atteint sa fin.",
-  
+
           // Ernesto Quest
           // Slate note
           "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "Je suis aller chercher des... des ...<![CDATA[<i>Champignons</i>]]>. Ne prends pas ma place ! Je reviens vite. Va récupérer les <![CDATA[<color=orange>nouveaux codes de lancement</color>]]> à l'Observatoire, Cornée les a changés à la dernière minute.",
-  
+
           // Hornfels
           "Hornfels": "Cornée",
           "<![CDATA[<color=orange>Ernesto</color>]]> disappeared!": "<![CDATA[<color=orange>Ernesto</color>]]> a disparu !",
@@ -82,13 +82,13 @@
           "Oh, I'm sorry about that...": "Oh, je suis désolé pour ça...",
           "Poor <![CDATA[<color=orange>Ernesto</color>]]>... Here's your <![CDATA[<color=orange>new launch codes</color>]]>...": "Pauvre <![CDATA[<color=orange>Ernesto</color>]]>... Voici tes <![CDATA[<color=orange>nouveaux codes de lancement</color>]]>...",
           "I just need <![CDATA[<color=orange>new launch codes</color>]]>.": "J'ai juste besoin des <![CDATA[<color=orange>nouveaux codes de lancement</color>]]>.",
-  
+
           // Slate
           "Slate": "Ardoise",
           "Oh, why are you still here? Did you get the <![CDATA[<color=orange>new launch codes</color>]]> yet?": "Oh, pourquoi es-tu encore là ? As-tu déjà récupéré les <![CDATA[<color=orange>nouveaux codes de lancement</color>]]> ?",
           "Is that the anglerfish from the museum?": "C'est le cœlacanthe du musée?",
           "<![CDATA[<color=orange>Ernesto</color>]]>?! NO!": "<![CDATA[<color=orange>Ernesto</color>]]>?! NON!",
-  
+
           "The anglerfish from the museum exhibition. Hornfels named it that.": "Le cœlacanthe de l'exposition du musée. Cornée l'a appelée comme ça.",
           "Okay, you know what? Yes, it is the anglerfish from the museum. I'm fed up with marshmallow. I can't take it anymore.": "Ok, tu sais quoi ? Oui, c'est le cœlacanthe du musée. J'en ai marre des guimauves. Je ne peux plus le supporter.",
           "So you decided to eat <![CDATA[<color=orange>Ernesto</color>]]>?! Hornfels said <![CDATA[<color=orange>Ernesto</color>]]> is a friend!": "Alors tu as décidé de manger <![CDATA[<color=orange>Ernesto</color>]]>?! Cornée a dit que <![CDATA[<color=orange>Ernesto</color>]]> est un ami !",
@@ -99,39 +99,39 @@
           "You'll do that for me? Thanks! Just don't tell anyone about <![CDATA[<color=orange>Ernesto</color>]]> alright?": "Tu feras ça pour moi ? Merci. Mais ne parle à personne de <![CDATA[<color=orange>Ernesto</color>]]>, d'accord?",
           "There is no accounting for tastes.": "Les goûts ne se discutent pas.",
           "Thank you! Get back within <![CDATA[<i>30 minutes</i>]]> and I'll give you a bite.": "Merci ! Reviens dans <![CDATA[<i>30 minutes</i>]]> et je t'en donnerai une bouchée.",
-  
+
           // Ship dialogue
           "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "Hmm... Cela semble être un bon endroit pour une torche de vision ! Je peux la mettre ici si nécessaire."
-  
-  
+
+
       },
       "UIDictionary": {
-  
+
           "Quantum Consciousness": "Conscience quantique",
           "Solanum": "Solanum",
           "GloamingGalaxy": "Vesperal",
           "THE_VISION_NEW_LAUNCH_CODES": "Nouveaux codes de lancement: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-  
+
           "THE_VISION_TO_BE_CONTINUED": "TOI ET SOLANUM VOUS ÉCHAPPEZ BIEN AU-DELÀ DE LA PORTÉE DE LA SUPERNOVA ET RENCONTREZ LES NOMAI SUR FULIGINA. \nENSEMBLE, VOUS VOYEZ LES ÉTOILES S'ÉTEINDRE.", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
           "THE_VISION_POPUP": "Merci d'avoir téléchargé «The Vision» ! Vérifiez les journaux de bord de votre vaisseau pour commencer une nouvelle histoire."
           // Thank you for downloading «The Vision»! Check your ship logs to start new story. If you’re having trouble with viewing the vision, please try lower your game resolution.
-  
+
       },
       "ShipLogDictionary": {
-  
+
           // Brittle Hollow
           "Solanum in the School Ruins": "Solanum dans les ruines de l'école",
           "Solanum on Brittle Hollow": "Solanum sur Cravité",
           "I can hear Solanum's signal coming from Brittle Hollow.": "Je peux entendre le signal de Solanum venant de Cravité.",
           "I found Solanum in the School.": "J'ai trouvé Solanum dans l'école.",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "Solanum a dit que c'est ici qu'elle allait à l'école. Elle a aussi mentionné que le trou noir était beaucoup plus petit avant. Elle a pris un cristal de gravité pour éviter de tomber.",
-  
+
           // CaveTwin_Body
           "Solanum in the Sunless City": "Solanum dans la cité obscure",
           "I can hear Solanum's signal coming from the Sunless City.": "Je peux entendre le signal de Solanum venant de la cité obscure.",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "J'ai trouvé Solanum dans la cité obscure. Elle est chez elle dans le quartier du Temple de l'Oeil.",
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Elle est attristée de voir la Cité Obscure en ruines. Solanum a raconté un peu de son enfance.",
-  
+
           // DB_VesselBody
           "Solanum on the Vessel": "Solanum dans le Vaisseau",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "Solanum veut essayer d'atteindre le Vaisseau. Est-il possible pour elle d'entrer dans Sombronces?",
@@ -140,13 +140,13 @@
           "Gloaming Galaxy, Blackrock coordinates hologram": "hologramme des coordonnées de Fuligina,Vesperal",
           "New coordinates": "Nouvelles coordonnées",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "J'ai trouvé les coordonnées de la Vesperal. Nous pouvons utiliser le générateur de distorsion du Projet Sablière noire pour nous téléporter. Il n'y aura pas de retour en arrière. Suis-je prêt à le faire ?",
-  
+
           // Giants Deep
           "Solanum on Giant's Deep": "Solanum sur Léviathe",
           "Solanum wants to visit Giant's Deep, but she probably will stay on Timber Hearth as well.": "Solanum veut visiter le Léviathe, mais elle restera probablement aussi à Âtrebois.",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "J'ai trouvé Solanum en train d'observer les journaux de bord de la sonde. Je n'ai jamais vu d'ordinateurs Nomaï avec une telle lueur verte. Elle accède à l'ordinateur principal pour savoir combien de temps s'est écoulé.",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanum contemple l'Œil, et la vision qu'en ont les habitants de l'Étranger. Elle a aussi remarqué une Statue mnémonique qui fonctionne.",
-  
+
           // Quantum Moon
           "Solanum on Quantum Moon": "Solanum sur la Lune quantique",
           "What if..?": "Et si... ?",
@@ -157,20 +157,20 @@
           "Solanum left some text near her body": "Solanum a laissé un texte près de son corps",
           "There are some new inscriptions left very recently": "Il y a de nouvelles inscriptions laissées très récemment",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "Le message de Solanum s'est brusquement interrompu alors qu'elle mentionnait Âtrebois.",
-  
+
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "Torche de vision dans le laboratoire endommagé",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "Je crois qu'il y a une torche de vision quelque part dans le laboratoire endommagé. Je me demande si elle fonctionne encore.",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "J'ai trouvé cette torche de vision. Ses flammes fonctionnent toujours même dans l'espace où il n'y a pas d'oxygène.",
-  
+
           // Timber Hearth
           "Solanum on Timber Hearth": "Solanum sur Âtrebois",
           "Is Solanum on Timber Hearth?": "Est-ce que Solanum est sur Âtrebois?",
-          "New quantum frequency": "Nouvelle fréquence quantique",
+          "New quantum frequency?": "Nouvelle fréquence quantique?",
           "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "Le message de Solanum a été interrompu quand elle a mentionné Âtrebois. Peut-être qu'elle est là-bas ?",
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum est en quelque sorte apparue sur Âtrebois près du village. Il semble qu'elle observe les Âtriens.",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "Solanum a pensé à Âtrebois, puis y est apparue. Elle veut en savoir plus sur le module de Pistage sur Léviathe.",
-  
+
           // Quantum Consciousness
           "Quantum Consciousness": "Conscience quantique",
           "I've discovered strange frequency called Quantum Consciousness.": "J'ai découvert une fréquence étrange appelée Conscience quantique.",
@@ -178,20 +178,20 @@
           "Quantum Consciousness has a strong recognizable signal and it sounds similar to the Quantum Fluctuations. In fact, the signal is very strong. It can be heard even without signalscope.": "La Conscience quantique a un signal fort et reconnaissable qui ressemble aux Fluctuations quantiques. En outre, le signal est très fort. On peut l'entendre même sans onduloscope.",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "Autre caractéristique notable de la Conscience quantique : des particules près de la tête du possesseur. Remarque : il semble que les autres règles quantiques ne s'appliquent pas à une Conscience quantique.",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "Un possesseur de Conscience quantique a en quelque sorte la capacité d'exister en plusieurs endroits à la fois. Selon Solanum, elle est capable d'apparaître à certains endroits en y pensant. Probablement, elle ne peut apparaître que dans les endroits qu'elle connaît.",
-  
-  
+
+
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "Solanum à l'intérieur du Projet Sablière Noire",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "Solanum veut vérifier le panneau de contrôle de la boucle temporelle. Je la trouverai peut-être à l'intérieur du Projet Sablière Noire.",
           "Solanum is already here. She observing the time loop ring's logs.": "Solanum est déjà là. Elle observe les journaux de la boucle temporelle.",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": " À présent, qu'elle sait pour la boucle temporelle et que notre Soleil va bientôt devenir une supernova. Solanum veut atteindre le Vaisseau, mais elle souhaite aussi revisiter les lieux de son enfance. Je peux essayer de la trouver sur le Vaisseau, ou ailleurs.",
-  
+
           "Paired Statue": "Statue liée",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "Solanum est passée juste à côté de la statue non liée dans le projet Sablière Noire. Maintenant, elle est aussi coincée dans la boucle temporelle.",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Au cycle précédent, Solanum n'était pas sûre du fonctionnement de la boucle temporelle. Ce cycle, il semble qu'elle ait tout compris et veut maintenant aller sur le Vaisseau.",
-  
-  
-          // Ernesto Quest        
+
+
+          // Ernesto Quest
           "Where is Ernesto?": "Où est Ernesto?",
           "Seriously, how could an anglerfish just disappear?": "Sérieusement, comment un coelacanthe peut-il disparaître ?",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Cornée a déclaré que le coelacanthe «Ernesto» avait disparu de l'exposition.",
@@ -199,6 +199,6 @@
           "I found Ernesto": "J'ai trouvé Ernesto",
           "I found Slate with Ernesto. He's cooking him on campfire.": "J'ai trouvé Ardoise avec Ernesto. Il le fait cuire sur le feu de camp.",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Ardoise en a marre des guimauves, c'est pourquoi il a décidé de faire cuire Ernesto. Il a dit qu'il sera prêt dans 30 minutes. Aucune intervention n'est nécessaire car la boucle se réinitialisera avant que cela n'arrive."
-          
+
       }
   }

--- a/translations/french.json
+++ b/translations/french.json
@@ -1,13 +1,13 @@
 {
     "$schema": "https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/translation_schema.json",
       "DialogueDictionary": {
-
+  
           // Hint: use «» instead of "".
           // Computer GD
           "MAIN COMPUTER: Log access granted, SOLANUM. USER REQUEST: «Last access granted». Calculating...": "ORDINATEUR PRINCIPAL: accès au journal accordé, SOLANUM. \nREQUETE UTILISATEUR: «Dernier accès accorder». calcul en cours...", // use \n here to enter new line
           "MAIN COMPUTER: Last access granted 281,042 years ago. USER = Mallow.": "ORDINATEUR PRINCIPAL: Dernier accès accorder il y a 281,042 années. \nUTILISATEUR = Mallow.", // and here
           "Visualizing progress. Deep space anomaly matching all known criteria for the <![CDATA[<color=lightblue>Eye of the universe</color>]]> has been found.": "Visualisation du progrès. Une anomalie dans l'espace lointain correspondant à tous les critères connus pour l'<![CDATA[<color=lightblue>Œil de l'univers</color>]]> a été découverte.",
-
+  
           // Computer ATP
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutes>]]> MINUTES, <![CDATA[<TimeSeconds>]]> SECONDS AGO: Data received from previous cycles."
           "ASH TWIN PROJECT: Receiving data cycle set up to <![CDATA[<color=orange>22 MINUTES</color>]]>.": "IL Y A <![CDATA[<TimeMinutes>]]> MINUTES ET <![CDATA[<TimeSeconds>]]> SECONDES: Données reçues des cycles précédents.",
@@ -16,7 +16,7 @@
           // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
           "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTES AVANT LA TRANSMISSION DE FIN DE CYCLE.",
           "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "ATTENTION: Retirer le générateur désactivera le <![CDATA[<color=orange>Projet Sablière noir</color>]]>.",
-
+  
           // Quantum Moon
           "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM : C'est étrange. Où suis-je ? Je vois des étoiles maintenant. Il est probable que je trouve les réponses dans le ciel.",
           "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM : C'est étrange, je ne me sens pas morte. C'est peut-être mon incertitude passée. Cet endroit me semble familier. Je suppose que c'est un état de Âtrebo...",
@@ -31,7 +31,7 @@
           "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM : Pourtant, des étrangers venus d'un autre système stellaire avaient des connaissances importantes. Ils avaient une technologie permettant de mieux comprendre l'<![CDATA[<color=lightblue>Oeil</color>]]>. J'ai une hypothèse que l'<![CDATA[<color=lightblue>Oeil</color>]]> est dangereux, basée sur leur vision. Cependant, leur interprétation pourrait être erronée.",
           "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM : Que faisons-nous de ces connaissances sur l' < ![CDATA[<color=lightblue>Eye</color>]]> ? Je veux en apprendre davantage à son sujet, et je veux le trouver - mais je ne sais pas comment l'atteindre.",
           "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM : Est-ce que je me trompe ? Est-ce que cette Statue mnémonique est active ? Dans cet état actif, elle devrait transmettre des données au <!CDATA[<color=orange>Projet Sablière noir</color>]>... Je vais y jeter un coup d'oeil.",
-          // Recorder ATP
+          // Recorder ATP 
           "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM : Je suppose que vous avez vu ceci ? Notre soleil est en train de mourir... mais vous êtes liés à l'une des statues ? Maintenant je comprends. Savez-vous qui d'autre est jumelé la statue de < ![CDATA[<color=lightblue>Léviathe</color>]]> ?",
           "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM : C'est regrettable. Il y a beaucoup de questions que je voudrais vous poser si je pouvais comprendre votre langue.",
           "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM : Peut-être, maintenant je suis lié à la Statue de la même façon que vous. Je me suis retrouvé juste en face de cette statue toute proche et elle a ouvert les yeux.",
@@ -62,17 +62,17 @@
           "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "SOLANUM : Penser à une telle possibilité est excitant. Mais je n'en ai pas peur. En fait, après tout ce qui s'est passé, je n'ai aucune crainte. Ce sont simplement les lois par lesquelles l'univers vie.",
           "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "SOLANUM: Deux observateurs conscients entament un voyage vers le destin. Je sens que l'incertitude grandit énormément. Elle n'a pas été aussi forte depuis que j'ai quitté la < ![CDATA[<color=lightblue>Lune Quantique</color>]]>.",
           "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "SOLANUM : Il n'y aura pas de retour en arrière. Je suis prêt pour ce qui va suivre, mon ami. La décision vous appartient.",
-
+  
           // EYE SCENE
           "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM : Deux observateurs conscients ont atteint l'Œil de l'univers. J'accepte votre décision.",
           "SOLANUM: Would you try to enter it?": "SOLANUM : Essayeriez-vous d'y entrer ?",
           "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, la dernière Nomai en vie, a acquis la Conscience Quantique à la suite d'un paradoxe. Elle est entrée dans l'Oeil avec moi.",
           "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "J'étais dans la < ![CDATA[<color=lightblue>Cité Obscure</color>]]>. J'y ai rencontré d'autres Nomai : Laevi, Tage, Lami et d'autres. Peut-être que notre voyage a atteint sa fin.",
-
+  
           // Ernesto Quest
           // Slate note
           "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "Je suis aller chercher des... des ...<![CDATA[<i>Champignons</i>]]>. Ne prends pas ma place ! Je reviens vite. Va récupérer les <![CDATA[<color=orange>nouveaux codes de lancement</color>]]> à l'Observatoire, Cornée les a changés à la dernière minute.",
-
+  
           // Hornfels
           "Hornfels": "Cornée",
           "<![CDATA[<color=orange>Ernesto</color>]]> disappeared!": "<![CDATA[<color=orange>Ernesto</color>]]> a disparu !",
@@ -82,13 +82,13 @@
           "Oh, I'm sorry about that...": "Oh, je suis désolé pour ça...",
           "Poor <![CDATA[<color=orange>Ernesto</color>]]>... Here's your <![CDATA[<color=orange>new launch codes</color>]]>...": "Pauvre <![CDATA[<color=orange>Ernesto</color>]]>... Voici tes <![CDATA[<color=orange>nouveaux codes de lancement</color>]]>...",
           "I just need <![CDATA[<color=orange>new launch codes</color>]]>.": "J'ai juste besoin des <![CDATA[<color=orange>nouveaux codes de lancement</color>]]>.",
-
+  
           // Slate
           "Slate": "Ardoise",
           "Oh, why are you still here? Did you get the <![CDATA[<color=orange>new launch codes</color>]]> yet?": "Oh, pourquoi es-tu encore là ? As-tu déjà récupéré les <![CDATA[<color=orange>nouveaux codes de lancement</color>]]> ?",
           "Is that the anglerfish from the museum?": "C'est le cœlacanthe du musée?",
           "<![CDATA[<color=orange>Ernesto</color>]]>?! NO!": "<![CDATA[<color=orange>Ernesto</color>]]>?! NON!",
-
+  
           "The anglerfish from the museum exhibition. Hornfels named it that.": "Le cœlacanthe de l'exposition du musée. Cornée l'a appelée comme ça.",
           "Okay, you know what? Yes, it is the anglerfish from the museum. I'm fed up with marshmallow. I can't take it anymore.": "Ok, tu sais quoi ? Oui, c'est le cœlacanthe du musée. J'en ai marre des guimauves. Je ne peux plus le supporter.",
           "So you decided to eat <![CDATA[<color=orange>Ernesto</color>]]>?! Hornfels said <![CDATA[<color=orange>Ernesto</color>]]> is a friend!": "Alors tu as décidé de manger <![CDATA[<color=orange>Ernesto</color>]]>?! Cornée a dit que <![CDATA[<color=orange>Ernesto</color>]]> est un ami !",
@@ -99,39 +99,39 @@
           "You'll do that for me? Thanks! Just don't tell anyone about <![CDATA[<color=orange>Ernesto</color>]]> alright?": "Tu feras ça pour moi ? Merci. Mais ne parle à personne de <![CDATA[<color=orange>Ernesto</color>]]>, d'accord?",
           "There is no accounting for tastes.": "Les goûts ne se discutent pas.",
           "Thank you! Get back within <![CDATA[<i>30 minutes</i>]]> and I'll give you a bite.": "Merci ! Reviens dans <![CDATA[<i>30 minutes</i>]]> et je t'en donnerai une bouchée.",
-
+  
           // Ship dialogue
           "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "Hmm... Cela semble être un bon endroit pour une torche de vision ! Je peux la mettre ici si nécessaire."
-
-
+  
+  
       },
       "UIDictionary": {
-
+  
           "Quantum Consciousness": "Conscience quantique",
           "Solanum": "Solanum",
           "GloamingGalaxy": "Vesperal",
           "THE_VISION_NEW_LAUNCH_CODES": "Nouveaux codes de lancement: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-
+  
           "THE_VISION_TO_BE_CONTINUED": "TOI ET SOLANUM VOUS ÉCHAPPEZ BIEN AU-DELÀ DE LA PORTÉE DE LA SUPERNOVA ET RENCONTREZ LES NOMAI SUR FULIGINA. \nENSEMBLE, VOUS VOYEZ LES ÉTOILES S'ÉTEINDRE.", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
           "THE_VISION_POPUP": "Merci d'avoir téléchargé «The Vision» ! Vérifiez les journaux de bord de votre vaisseau pour commencer une nouvelle histoire."
           // Thank you for downloading «The Vision»! Check your ship logs to start new story. If you’re having trouble with viewing the vision, please try lower your game resolution.
-
+  
       },
       "ShipLogDictionary": {
-
+  
           // Brittle Hollow
           "Solanum in the School Ruins": "Solanum dans les ruines de l'école",
           "Solanum on Brittle Hollow": "Solanum sur Cravité",
           "I can hear Solanum's signal coming from Brittle Hollow.": "Je peux entendre le signal de Solanum venant de Cravité.",
           "I found Solanum in the School.": "J'ai trouvé Solanum dans l'école.",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "Solanum a dit que c'est ici qu'elle allait à l'école. Elle a aussi mentionné que le trou noir était beaucoup plus petit avant. Elle a pris un cristal de gravité pour éviter de tomber.",
-
+  
           // CaveTwin_Body
           "Solanum in the Sunless City": "Solanum dans la cité obscure",
           "I can hear Solanum's signal coming from the Sunless City.": "Je peux entendre le signal de Solanum venant de la cité obscure.",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "J'ai trouvé Solanum dans la cité obscure. Elle est chez elle dans le quartier du Temple de l'Oeil.",
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Elle est attristée de voir la Cité Obscure en ruines. Solanum a raconté un peu de son enfance.",
-
+  
           // DB_VesselBody
           "Solanum on the Vessel": "Solanum dans le Vaisseau",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "Solanum veut essayer d'atteindre le Vaisseau. Est-il possible pour elle d'entrer dans Sombronces?",
@@ -140,13 +140,13 @@
           "Gloaming Galaxy, Blackrock coordinates hologram": "hologramme des coordonnées de Fuligina,Vesperal",
           "New coordinates": "Nouvelles coordonnées",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "J'ai trouvé les coordonnées de la Vesperal. Nous pouvons utiliser le générateur de distorsion du Projet Sablière noire pour nous téléporter. Il n'y aura pas de retour en arrière. Suis-je prêt à le faire ?",
-
+  
           // Giants Deep
           "Solanum on Giant's Deep": "Solanum sur Léviathe",
           "Solanum wants to visit Giant's Deep, but she probably will stay on Timber Hearth as well.": "Solanum veut visiter le Léviathe, mais elle restera probablement aussi à Âtrebois.",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "J'ai trouvé Solanum en train d'observer les journaux de bord de la sonde. Je n'ai jamais vu d'ordinateurs Nomaï avec une telle lueur verte. Elle accède à l'ordinateur principal pour savoir combien de temps s'est écoulé.",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanum contemple l'Œil, et la vision qu'en ont les habitants de l'Étranger. Elle a aussi remarqué une Statue mnémonique qui fonctionne.",
-
+  
           // Quantum Moon
           "Solanum on Quantum Moon": "Solanum sur la Lune quantique",
           "What if..?": "Et si... ?",
@@ -157,12 +157,12 @@
           "Solanum left some text near her body": "Solanum a laissé un texte près de son corps",
           "There are some new inscriptions left very recently": "Il y a de nouvelles inscriptions laissées très récemment",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "Le message de Solanum s'est brusquement interrompu alors qu'elle mentionnait Âtrebois.",
-
+  
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "Torche de vision dans le laboratoire endommagé",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "Je crois qu'il y a une torche de vision quelque part dans le laboratoire endommagé. Je me demande si elle fonctionne encore.",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "J'ai trouvé cette torche de vision. Ses flammes fonctionnent toujours même dans l'espace où il n'y a pas d'oxygène.",
-
+  
           // Timber Hearth
           "Solanum on Timber Hearth": "Solanum sur Âtrebois",
           "Is Solanum on Timber Hearth?": "Est-ce que Solanum est sur Âtrebois?",
@@ -170,7 +170,7 @@
           "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "Le message de Solanum a été interrompu quand elle a mentionné Âtrebois. Peut-être qu'elle est là-bas ?",
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum est en quelque sorte apparue sur Âtrebois près du village. Il semble qu'elle observe les Âtriens.",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "Solanum a pensé à Âtrebois, puis y est apparue. Elle veut en savoir plus sur le module de Pistage sur Léviathe.",
-
+  
           // Quantum Consciousness
           "Quantum Consciousness": "Conscience quantique",
           "I've discovered strange frequency called Quantum Consciousness.": "J'ai découvert une fréquence étrange appelée Conscience quantique.",
@@ -178,20 +178,20 @@
           "Quantum Consciousness has a strong recognizable signal and it sounds similar to the Quantum Fluctuations. In fact, the signal is very strong. It can be heard even without signalscope.": "La Conscience quantique a un signal fort et reconnaissable qui ressemble aux Fluctuations quantiques. En outre, le signal est très fort. On peut l'entendre même sans onduloscope.",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "Autre caractéristique notable de la Conscience quantique : des particules près de la tête du possesseur. Remarque : il semble que les autres règles quantiques ne s'appliquent pas à une Conscience quantique.",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "Un possesseur de Conscience quantique a en quelque sorte la capacité d'exister en plusieurs endroits à la fois. Selon Solanum, elle est capable d'apparaître à certains endroits en y pensant. Probablement, elle ne peut apparaître que dans les endroits qu'elle connaît.",
-
-
+  
+  
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "Solanum à l'intérieur du Projet Sablière Noire",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "Solanum veut vérifier le panneau de contrôle de la boucle temporelle. Je la trouverai peut-être à l'intérieur du Projet Sablière Noire.",
           "Solanum is already here. She observing the time loop ring's logs.": "Solanum est déjà là. Elle observe les journaux de la boucle temporelle.",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": " À présent, qu'elle sait pour la boucle temporelle et que notre Soleil va bientôt devenir une supernova. Solanum veut atteindre le Vaisseau, mais elle souhaite aussi revisiter les lieux de son enfance. Je peux essayer de la trouver sur le Vaisseau, ou ailleurs.",
-
+  
           "Paired Statue": "Statue liée",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "Solanum est passée juste à côté de la statue non liée dans le projet Sablière Noire. Maintenant, elle est aussi coincée dans la boucle temporelle.",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Au cycle précédent, Solanum n'était pas sûre du fonctionnement de la boucle temporelle. Ce cycle, il semble qu'elle ait tout compris et veut maintenant aller sur le Vaisseau.",
-
-
-          // Ernesto Quest
+  
+  
+          // Ernesto Quest        
           "Where is Ernesto?": "Où est Ernesto?",
           "Seriously, how could an anglerfish just disappear?": "Sérieusement, comment un coelacanthe peut-il disparaître ?",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Cornée a déclaré que le coelacanthe «Ernesto» avait disparu de l'exposition.",
@@ -199,6 +199,6 @@
           "I found Ernesto": "J'ai trouvé Ernesto",
           "I found Slate with Ernesto. He's cooking him on campfire.": "J'ai trouvé Ardoise avec Ernesto. Il le fait cuire sur le feu de camp.",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Ardoise en a marre des guimauves, c'est pourquoi il a décidé de faire cuire Ernesto. Il a dit qu'il sera prêt dans 30 minutes. Aucune intervention n'est nécessaire car la boucle se réinitialisera avant que cela n'arrive."
-
+          
       }
   }

--- a/translations/german.json
+++ b/translations/german.json
@@ -18,21 +18,21 @@
         "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "NOCH <![CDATA[<TimeMinutesRemaining>]]> MINUTEN BIS ZUR ZYKLUS-ENDÜBERTRAGUNG.",
         "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "WARNUNG! Das Entfernen des Kerns deaktiviert das <![CDATA[<color=orange>Projekt Zwillingsasche</color>]]>.",
 
-        // Quantum Moon	
+        // Quantum Moon
         "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: Das ist seltsam. Wo bin ich? Ich sehe jetzt Sterne. Wahrscheinlich finde ich die Antworten oben im Himmel.",
         "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: Seltsam, ich fühle mich nicht tot. Vielleicht ist das meine vergangene Unbestimmbarkeit. Dieser Ort kommt mir bekannt vor. Ich nehme an das ist der Zustand von Holzka...",
-        // Recorder TH	
+        // Recorder TH
         "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Grüße, mein Freund. Ich fühle mich anders, aber es ist schwer zu erklären.",
         "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: Ich bin mir nicht sicher wie ich hier her kam. Ich würde mutmaßen, dass der Gedanke an diesen Ort mich irgendwie hier her brachte. Das ist mir vorher noch nie passiert.",
         "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: Du hast mir den Tod meines Clans gezeigt. Es ist schwer das zu verarbeiten. Was denkst du, wie lange es seitdem her ist? Ich kann mich genau erinnern, wie mich Bells auf meine Pilgerreise zum <![CDATA[<color=lightblue>Quantummond</color>]]> führte. Ich vermute, dass meine Pilgerreise ihr Ende gefunden hat.",
         "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: Ich habe noch nie jemanden von deiner Spezies getroffen. Es ist mir eine Ehre mit dir zu sprechen, selbst per Rekorder. Du hast meinen Dank dafür, dass du meine Sprache verstehen kannst.",
         "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: Ich bin froh deine Rasse beobachten zu können. Ich kann mir vorstellen, dass du den selben Durst nach Wissen hast, wie wir es tun. Ich glaube, ich habe die <![CDATA[<color=orange>Sonden-Orbitalkanone</color>]]> gesehen und dass es kaputt ist. Es ist Zeit herauszufinden, welche Daten es sammeln konnte.",
-        // Recorder GD	
+        // Recorder GD
         "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: Wir haben endlich das <![CDATA[<color=lightblue>Auge des Universum</color>]]> gefunden. Ich wünschte mein Clan könnte das sehen.",
         "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Trotzdem, die Fremden von einem anderen Sternsystem hatten wichtiges Wissen. Sie hatten Technologie, womit sie das <![CDATA[<color=lightblue>Auge</color>]]> besser verstehen konnten. Ich habe die Hypothese, dass das <![CDATA[<color=lightblue>Auge</color>]]> gefährlich ist, basierend auf deren Vision. Jedoch könnte ihre Interpretation auch falsch sein.",
         "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: Was tun wir mit diesem Wissen über das <![CDATA[<color=lightblue>Auge</color>]]>? Ich möchte mehr darüber lernen und ich möchte es finden - aber ich bin mir nicht sicher, wie wir es erreichen sollen.",
         "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Liege ich falsch? Ist diese Gedächtnisstatue aktiv? In diesem aktivierten Zustand sollte es Daten an <![CDATA[<color=orange>Projekt Zwillingsasche</color>]]> übertragen.. Ich schaue mir das mal an.",
-        // Recorder ATP 	
+        // Recorder ATP
         "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: Ich vermute, dass du es schon gesehen hast? Unsere Sonne stirbt... aber bist du mit einer der Statuen verknüpft? Jetzt verstehe ich es. Weißt du wer auf den <![CDATA[<color=lightblue>Untiefen der Riesen</color>]]> verknüpft ist?",
         "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: Es ist schade. Es gibt so viele Fragen, die ich stellen würde, wenn ich deine Sprache verstehen könnte.",
         "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Möglicherweise bin ich jetzt, auf die selbe Weise wie du, mit dieser Statue dort drüben verbunden. Ich landete direkt vor der Statue und sie öffnete ihre Augen.",
@@ -40,21 +40,21 @@
         "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: Ich hatte ein Zeitschleifen-Spielzeug als ich ein Kind war, aber ich war mir nicht sicher wie die echte Zeitschleife funktioniert hätte. Ich sollte, vor der Abreise, zuerst ein paar <![CDATA[<color=lightblue>Orte meiner Kindheit</color>]]> besuchen.",
         "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: Wenn die <![CDATA[<color=lightblue>Sonne</color>]]> stirbt, müssten wir gefangen sein. Hypothese: Es ist möglich zu überleben, wenn wir weit genug davon wegkommen. Das wäre eine mögliche Lösung.",
         "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: Von deiner Vision weiß ich jetzt, dass <![CDATA[<color=orange>das Gefährt</color>]]> sich in <![CDATA[<color=lightblue>Schwarzdorn</color>]]> befindet. Denkst ich könnte es erreichen, so wie ich diesen Ort erreicht habe?",
-        // Recorder ATP 2	
+        // Recorder ATP 2
         "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: Ich verstehe jetzt, wie die Zeitschleife funktioniert und ich kann mich auch an alles aus dem vorherigen Zyklus erinnern.",
         "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz sagte: <![CDATA[<i>«Das Zurücksenden von Erinnerungen in der Zeit und selbst in der Zeit zurückreisen sind zwei verschiedene Aktionen»</i>]]>.",
         "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: Ich kann mir vorstellen, dass solch eine Technologie es würdig wäre, auf dem Nomaifestival gefeiert zu werden. Wir sollten jetzt versuchen zum <![CDATA[<color=orange>Gefährt</color>]]> zu kommen. Ich werde den Kern noch einmal öffnen, aber in der nächsten Schleife bist du dran.",
-        // Recorder BH	
+        // Recorder BH
         "SOLANUM: This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM: Dies war meine Schule, wo wir beide jetzt stehen. Hier lernte ich über das Universum: Sterne, Raum und Zeit. Ich gehe davon aus, dass es kein sicherer Ort mehr ist. Ich bin mir nicht sicher, aber ich habe das schwarze Loch viel kleiner in Erinnerung.",
         "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: Als ein Schüler stellte ich mir vor wie das Universum kollabiert. Conoy erzählte mir, dass es nicht zu unseren Lebzeiten passieren würde. Es war gruselig daran zu denken. Aber was kommt danach? Vielleicht bildet es etwas neues.",
         "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: Es könnte hier unsicher sein, deswegen brachte ich diesen Gravitationskristall. Auf diesem Planeten sind Raum und Zeit untrennbar verbunden und begrenzt.",
         "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: Ich nehme an, dass dieser Kristall nicht komplett stabil ist. Womöglich liegt das an der steigenden Fluktuation des schwarzen Lochs. Sei vorsichtig.",
-        // Recorder ET	
+        // Recorder ET
         "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: Ich verbrachte meine Kindheit hier. Mein Zuhause und das meiner Familie und meinen Freunden. Die Stadt liegt nun in Trümmern...es ist traurig es so anzusehen.",
         "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: Als ich ein Kind war, liebte ich diese Spielzeuge. Das Pyramidion und das Shuttle waren beide meine Favoriten. Das ist nur ein kleiner Teil vom kulturellem Erbe der Nomai.",
         "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: Ich denke, hier ist es nicht sicher. Ich kann den Sand aufsteigen hören.",
         "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: Ich glaube nicht, dass sie noch für jemandem einen Nutzen haben werden. Bitte nimm etwas Abstand.",
-        // Recorder DB	
+        // Recorder DB
         "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: Es ist unglaublich! Die Hauptsysteme funktionieren, trotz des Schadens. Ich bin sicher ich kann damit umgehen.",
         "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: Diese Wand zeigt eingehende Nachrichten von anderen Nomaiclans an. Es mag seltsam klingen, aber sie glauben, dass das Verschwinden von Escalls Gefährt bloß ein Mythos war.",
         "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: Es ist unglaublich, dass <![CDATA[<color=orange>das Gefährt</color>]]> Nachrichten hier in <![CDATA[<color=lightblue>Schwarzdorn</color>]]> empfangen kann. Vielleicht kann ich diese zurückverfolgen...",
@@ -66,7 +66,7 @@
 
 
 
-        // EYE SCENE	
+        // EYE SCENE
         "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Zwei bewusste Beobachter haben das Auge des Universums erreicht. Ich akzeptiere deine Entscheidung.",
         "SOLANUM: Would you try to enter it?": "SOLANUM: Würdest du versuchen es zu betreten?",
         "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, die letzte lebende Nomai, erhielt das Quantenbewusstsein durch das Resultat eines Paradoxons. Sie hat mit mir das Auge betreten.",
@@ -134,7 +134,7 @@
         "Solanum in the Sunless City": "Solanum in der Sonnenlosen Stadt",
         "I can hear Solanum's signal coming from the Sunless City.": "Ich kann Solanums Signal von der Sonnenlosen Stadt aus hören.",
         "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "Ich fand Solanum in der Sonnenlosen Stadt. Sie bleibt bei ihrem Zuhause im Augenschreinbezirk.",
-        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
+        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
         "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Sie fühlt sich traurig dabei die Ruinen der Sonnenlosen Stadt zu sehen. Solanum hatte mir etwas über ihre Kindheit erzählt.",
 
 
@@ -180,7 +180,7 @@
         // Timber Hearth
         "Solanum on Timber Hearth": "Solanum auf Holzkamin",
         "Is Solanum on Timber Hearth?": "Ist Solanum auf Holzkamin?",
-        "New quantum frequency": "Neue Quantenfrequenz",
+        "New quantum frequency?": "Neue Quantenfrequenz?",
         "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "Solanums Nachricht wurde unterbrochen, als sie Holzkamin erwähnte. Vielleicht ist sie dort?",
         "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum ist irgendwie auf Holzkamin in der Nähe des Dorfes aufgetaucht. Es scheint, als würde sie die Kamina beobachten.",
         //"According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.": "According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.",
@@ -213,7 +213,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Im letzten Zyklus war sich Solanum nicht sicher, wie die Zeitschleife funktioniert. In diesem Zyklus scheint sie aber alles verstanden zu haben und möchte jetzt zum Gefährt.",
 
 
-        // Ernesto Quest        
+        // Ernesto Quest
         "Where is Ernesto?": "Wo ist Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "Ernsthaft, wie kann ein Anglerfisch einfach verschwinden?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Hornfels sagte, dass der Anglerfisch «Ernesto» aus der Ausstellung verschwunden ist.",

--- a/translations/german.json
+++ b/translations/german.json
@@ -18,21 +18,21 @@
         "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "NOCH <![CDATA[<TimeMinutesRemaining>]]> MINUTEN BIS ZUR ZYKLUS-ENDÜBERTRAGUNG.",
         "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "WARNUNG! Das Entfernen des Kerns deaktiviert das <![CDATA[<color=orange>Projekt Zwillingsasche</color>]]>.",
 
-        // Quantum Moon
+        // Quantum Moon	
         "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: Das ist seltsam. Wo bin ich? Ich sehe jetzt Sterne. Wahrscheinlich finde ich die Antworten oben im Himmel.",
         "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: Seltsam, ich fühle mich nicht tot. Vielleicht ist das meine vergangene Unbestimmbarkeit. Dieser Ort kommt mir bekannt vor. Ich nehme an das ist der Zustand von Holzka...",
-        // Recorder TH
+        // Recorder TH	
         "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Grüße, mein Freund. Ich fühle mich anders, aber es ist schwer zu erklären.",
         "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: Ich bin mir nicht sicher wie ich hier her kam. Ich würde mutmaßen, dass der Gedanke an diesen Ort mich irgendwie hier her brachte. Das ist mir vorher noch nie passiert.",
         "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: Du hast mir den Tod meines Clans gezeigt. Es ist schwer das zu verarbeiten. Was denkst du, wie lange es seitdem her ist? Ich kann mich genau erinnern, wie mich Bells auf meine Pilgerreise zum <![CDATA[<color=lightblue>Quantummond</color>]]> führte. Ich vermute, dass meine Pilgerreise ihr Ende gefunden hat.",
         "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: Ich habe noch nie jemanden von deiner Spezies getroffen. Es ist mir eine Ehre mit dir zu sprechen, selbst per Rekorder. Du hast meinen Dank dafür, dass du meine Sprache verstehen kannst.",
         "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: Ich bin froh deine Rasse beobachten zu können. Ich kann mir vorstellen, dass du den selben Durst nach Wissen hast, wie wir es tun. Ich glaube, ich habe die <![CDATA[<color=orange>Sonden-Orbitalkanone</color>]]> gesehen und dass es kaputt ist. Es ist Zeit herauszufinden, welche Daten es sammeln konnte.",
-        // Recorder GD
+        // Recorder GD	
         "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: Wir haben endlich das <![CDATA[<color=lightblue>Auge des Universum</color>]]> gefunden. Ich wünschte mein Clan könnte das sehen.",
         "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Trotzdem, die Fremden von einem anderen Sternsystem hatten wichtiges Wissen. Sie hatten Technologie, womit sie das <![CDATA[<color=lightblue>Auge</color>]]> besser verstehen konnten. Ich habe die Hypothese, dass das <![CDATA[<color=lightblue>Auge</color>]]> gefährlich ist, basierend auf deren Vision. Jedoch könnte ihre Interpretation auch falsch sein.",
         "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: Was tun wir mit diesem Wissen über das <![CDATA[<color=lightblue>Auge</color>]]>? Ich möchte mehr darüber lernen und ich möchte es finden - aber ich bin mir nicht sicher, wie wir es erreichen sollen.",
         "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Liege ich falsch? Ist diese Gedächtnisstatue aktiv? In diesem aktivierten Zustand sollte es Daten an <![CDATA[<color=orange>Projekt Zwillingsasche</color>]]> übertragen.. Ich schaue mir das mal an.",
-        // Recorder ATP
+        // Recorder ATP 	
         "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: Ich vermute, dass du es schon gesehen hast? Unsere Sonne stirbt... aber bist du mit einer der Statuen verknüpft? Jetzt verstehe ich es. Weißt du wer auf den <![CDATA[<color=lightblue>Untiefen der Riesen</color>]]> verknüpft ist?",
         "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: Es ist schade. Es gibt so viele Fragen, die ich stellen würde, wenn ich deine Sprache verstehen könnte.",
         "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Möglicherweise bin ich jetzt, auf die selbe Weise wie du, mit dieser Statue dort drüben verbunden. Ich landete direkt vor der Statue und sie öffnete ihre Augen.",
@@ -40,21 +40,21 @@
         "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: Ich hatte ein Zeitschleifen-Spielzeug als ich ein Kind war, aber ich war mir nicht sicher wie die echte Zeitschleife funktioniert hätte. Ich sollte, vor der Abreise, zuerst ein paar <![CDATA[<color=lightblue>Orte meiner Kindheit</color>]]> besuchen.",
         "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: Wenn die <![CDATA[<color=lightblue>Sonne</color>]]> stirbt, müssten wir gefangen sein. Hypothese: Es ist möglich zu überleben, wenn wir weit genug davon wegkommen. Das wäre eine mögliche Lösung.",
         "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: Von deiner Vision weiß ich jetzt, dass <![CDATA[<color=orange>das Gefährt</color>]]> sich in <![CDATA[<color=lightblue>Schwarzdorn</color>]]> befindet. Denkst ich könnte es erreichen, so wie ich diesen Ort erreicht habe?",
-        // Recorder ATP 2
+        // Recorder ATP 2	
         "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: Ich verstehe jetzt, wie die Zeitschleife funktioniert und ich kann mich auch an alles aus dem vorherigen Zyklus erinnern.",
         "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz sagte: <![CDATA[<i>«Das Zurücksenden von Erinnerungen in der Zeit und selbst in der Zeit zurückreisen sind zwei verschiedene Aktionen»</i>]]>.",
         "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: Ich kann mir vorstellen, dass solch eine Technologie es würdig wäre, auf dem Nomaifestival gefeiert zu werden. Wir sollten jetzt versuchen zum <![CDATA[<color=orange>Gefährt</color>]]> zu kommen. Ich werde den Kern noch einmal öffnen, aber in der nächsten Schleife bist du dran.",
-        // Recorder BH
+        // Recorder BH	
         "SOLANUM: This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM: Dies war meine Schule, wo wir beide jetzt stehen. Hier lernte ich über das Universum: Sterne, Raum und Zeit. Ich gehe davon aus, dass es kein sicherer Ort mehr ist. Ich bin mir nicht sicher, aber ich habe das schwarze Loch viel kleiner in Erinnerung.",
         "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: Als ein Schüler stellte ich mir vor wie das Universum kollabiert. Conoy erzählte mir, dass es nicht zu unseren Lebzeiten passieren würde. Es war gruselig daran zu denken. Aber was kommt danach? Vielleicht bildet es etwas neues.",
         "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: Es könnte hier unsicher sein, deswegen brachte ich diesen Gravitationskristall. Auf diesem Planeten sind Raum und Zeit untrennbar verbunden und begrenzt.",
         "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: Ich nehme an, dass dieser Kristall nicht komplett stabil ist. Womöglich liegt das an der steigenden Fluktuation des schwarzen Lochs. Sei vorsichtig.",
-        // Recorder ET
+        // Recorder ET	
         "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: Ich verbrachte meine Kindheit hier. Mein Zuhause und das meiner Familie und meinen Freunden. Die Stadt liegt nun in Trümmern...es ist traurig es so anzusehen.",
         "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: Als ich ein Kind war, liebte ich diese Spielzeuge. Das Pyramidion und das Shuttle waren beide meine Favoriten. Das ist nur ein kleiner Teil vom kulturellem Erbe der Nomai.",
         "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: Ich denke, hier ist es nicht sicher. Ich kann den Sand aufsteigen hören.",
         "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: Ich glaube nicht, dass sie noch für jemandem einen Nutzen haben werden. Bitte nimm etwas Abstand.",
-        // Recorder DB
+        // Recorder DB	
         "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: Es ist unglaublich! Die Hauptsysteme funktionieren, trotz des Schadens. Ich bin sicher ich kann damit umgehen.",
         "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: Diese Wand zeigt eingehende Nachrichten von anderen Nomaiclans an. Es mag seltsam klingen, aber sie glauben, dass das Verschwinden von Escalls Gefährt bloß ein Mythos war.",
         "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: Es ist unglaublich, dass <![CDATA[<color=orange>das Gefährt</color>]]> Nachrichten hier in <![CDATA[<color=lightblue>Schwarzdorn</color>]]> empfangen kann. Vielleicht kann ich diese zurückverfolgen...",
@@ -66,7 +66,7 @@
 
 
 
-        // EYE SCENE
+        // EYE SCENE	
         "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Zwei bewusste Beobachter haben das Auge des Universums erreicht. Ich akzeptiere deine Entscheidung.",
         "SOLANUM: Would you try to enter it?": "SOLANUM: Würdest du versuchen es zu betreten?",
         "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, die letzte lebende Nomai, erhielt das Quantenbewusstsein durch das Resultat eines Paradoxons. Sie hat mit mir das Auge betreten.",
@@ -134,7 +134,7 @@
         "Solanum in the Sunless City": "Solanum in der Sonnenlosen Stadt",
         "I can hear Solanum's signal coming from the Sunless City.": "Ich kann Solanums Signal von der Sonnenlosen Stadt aus hören.",
         "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "Ich fand Solanum in der Sonnenlosen Stadt. Sie bleibt bei ihrem Zuhause im Augenschreinbezirk.",
-        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
+        // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
         "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Sie fühlt sich traurig dabei die Ruinen der Sonnenlosen Stadt zu sehen. Solanum hatte mir etwas über ihre Kindheit erzählt.",
 
 
@@ -213,7 +213,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Im letzten Zyklus war sich Solanum nicht sicher, wie die Zeitschleife funktioniert. In diesem Zyklus scheint sie aber alles verstanden zu haben und möchte jetzt zum Gefährt.",
 
 
-        // Ernesto Quest
+        // Ernesto Quest        
         "Where is Ernesto?": "Wo ist Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "Ernsthaft, wie kann ein Anglerfisch einfach verschwinden?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Hornfels sagte, dass der Anglerfisch «Ernesto» aus der Ausstellung verschwunden ist.",

--- a/translations/portuguese_br.json
+++ b/translations/portuguese_br.json
@@ -31,7 +31,7 @@
         "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: De qualquer modo, desconhecidos de um outro sistema solar tinham um importante conhecimento. Tinham a técnologia para entender melhor o <![CDATA[<color=lightblue>Olho</color>]]>. Hipótese: o <![CDATA[<color=lightblue>Olho</color>]]> é perigoso, baseando-se na visão deles. Todavia, a interpretação deles poderia estar equivocada.",
         "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: O que faremos com esse conhecimento sobre o <![CDATA[<color=lightblue>Olho</color>]]>? Quero aprender sobre ele, quero encontralo - mas não tenho certeza nem de como alcança-lo.",
         "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Estou enganada? Aquela Estátua de Memória está ativa? Em seu estado de ativada, ela deve estar transmitindo dados para o <![CDATA[<color=orange>Projeto do Gêmeo Cinzento</color>]]>.. Irei dar uma olhada nele.",
-        // Recorder ATP 
+        // Recorder ATP
         "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: Suspeito que tu já saibas disso? Que o nosso Sol está morrendo... mas tu estás pareado com uma das estátuas? Agora entendo. Tu tens ideia de quem mais está pareado nas ![CDATA[<color=lightblue>Profundezas do Gigante</color>]]>?",
         "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: É uma pena. Há tantas questões que eu perguntaria se eu compreende-se tua linguagem.",
         "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Talvez, agora estou ligada com a Estátua da mesma maneira que tu. Acabei em frente daquela máscara perto e seus olhos abriram.",
@@ -111,7 +111,7 @@
 
         "Quantum Consciousness": "Conciência Quântica",
         "Solanum": "Solanum",
-        "GloamingGalaxy": "Galáxia Gloaming", // Add this to other translations      
+        "GloamingGalaxy": "Galáxia Gloaming", // Add this to other translations
         "THE_VISION_NEW_LAUNCH_CODES": "Novos códigos de lançamento: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
 
         "THE_VISION_TO_BE_CONTINUED": "VOCÊ E SOLANUM ESCAPARAM PARA ALÉM DO ALCANCE DA SUPERNOVA E CONHECERAM A NOMAI EM BLACKROCK. \nJUNTOS VOCÊS ASSITEM AS ESTRELAS SE EXTINGUIREM.", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
@@ -167,7 +167,7 @@
         // Timber Hearth
         "Solanum on Timber Hearth": "Solanum no Recanto Lenhoso",
         "Is Solanum on Timber Hearth?": "Solanum está no Recanto Lenhoso?",
-        "New quantum frequency": "Nova frequência quântica",
+        "New quantum frequency?": "Nova frequência quântica?",
         "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "A mensagem da Solanum foi interrompida quando ela mencionou o Recanto Lenhoso. Talvez ela esteja lá?",
         "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum de alguma maneira apareçeu no Recanto Lenhoso perto da vila. Parece que ela está observando os Lenhosos.",
         "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "Solanum pensou no Recanto Lenhoso, e lá apareceu. Ele quer saber mais sobre o Módulo de Rastreamento de Sondas nas Profundezas do Gigante.",
@@ -191,7 +191,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Em ciclos anteriores, Solanum não sabia como o loop funcionava. Agora parece que ela tudo entende e quer ire ao Hospedeiro.",
 
 
-        // Ernesto Quest        
+        // Ernesto Quest
         "Where is Ernesto?": "Onde está Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "É sério, como que um tamboril apenas desaparece?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Corneana disse que aquele tamboril «Ernesto» desapareceu da exibição.",
@@ -199,6 +199,6 @@
         "I found Ernesto": "Encontrei Ernesto",
         "I found Slate with Ernesto. He's cooking him on campfire.": "Encontrei Ardósia com Ernesto. Ardósia está cozinhando ele no fogueira.",
         "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Ardósia está de saco cheio de comer apenas marshmallows, por isso está cozinhando o Ernerto. Dentro de 30 min ele estará pronto. Não é necessário uma intervensão pois o loop irá reiniciar antes que isso aconteça."
-        
+
     }
   }

--- a/translations/portuguese_br.json
+++ b/translations/portuguese_br.json
@@ -31,7 +31,7 @@
         "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: De qualquer modo, desconhecidos de um outro sistema solar tinham um importante conhecimento. Tinham a técnologia para entender melhor o <![CDATA[<color=lightblue>Olho</color>]]>. Hipótese: o <![CDATA[<color=lightblue>Olho</color>]]> é perigoso, baseando-se na visão deles. Todavia, a interpretação deles poderia estar equivocada.",
         "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: O que faremos com esse conhecimento sobre o <![CDATA[<color=lightblue>Olho</color>]]>? Quero aprender sobre ele, quero encontralo - mas não tenho certeza nem de como alcança-lo.",
         "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: Estou enganada? Aquela Estátua de Memória está ativa? Em seu estado de ativada, ela deve estar transmitindo dados para o <![CDATA[<color=orange>Projeto do Gêmeo Cinzento</color>]]>.. Irei dar uma olhada nele.",
-        // Recorder ATP
+        // Recorder ATP 
         "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: Suspeito que tu já saibas disso? Que o nosso Sol está morrendo... mas tu estás pareado com uma das estátuas? Agora entendo. Tu tens ideia de quem mais está pareado nas ![CDATA[<color=lightblue>Profundezas do Gigante</color>]]>?",
         "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: É uma pena. Há tantas questões que eu perguntaria se eu compreende-se tua linguagem.",
         "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Talvez, agora estou ligada com a Estátua da mesma maneira que tu. Acabei em frente daquela máscara perto e seus olhos abriram.",
@@ -111,7 +111,7 @@
 
         "Quantum Consciousness": "Conciência Quântica",
         "Solanum": "Solanum",
-        "GloamingGalaxy": "Galáxia Gloaming", // Add this to other translations
+        "GloamingGalaxy": "Galáxia Gloaming", // Add this to other translations      
         "THE_VISION_NEW_LAUNCH_CODES": "Novos códigos de lançamento: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
 
         "THE_VISION_TO_BE_CONTINUED": "VOCÊ E SOLANUM ESCAPARAM PARA ALÉM DO ALCANCE DA SUPERNOVA E CONHECERAM A NOMAI EM BLACKROCK. \nJUNTOS VOCÊS ASSITEM AS ESTRELAS SE EXTINGUIREM.", // "YOU AND SOLANUM ESCAPE FAR BEYOND THE REACH OF THE SUPERNOVA AND MEET THE NOMAI ON BLACKROCK. \nTOGETHER YOU WATCH THE STARS GO OUT."
@@ -191,7 +191,7 @@
         "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Em ciclos anteriores, Solanum não sabia como o loop funcionava. Agora parece que ela tudo entende e quer ire ao Hospedeiro.",
 
 
-        // Ernesto Quest
+        // Ernesto Quest        
         "Where is Ernesto?": "Onde está Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "É sério, como que um tamboril apenas desaparece?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Corneana disse que aquele tamboril «Ernesto» desapareceu da exibição.",
@@ -199,6 +199,6 @@
         "I found Ernesto": "Encontrei Ernesto",
         "I found Slate with Ernesto. He's cooking him on campfire.": "Encontrei Ardósia com Ernesto. Ardósia está cozinhando ele no fogueira.",
         "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Ardósia está de saco cheio de comer apenas marshmallows, por isso está cozinhando o Ernerto. Dentro de 30 min ele estará pronto. Não é necessário uma intervensão pois o loop irá reiniciar antes que isso aconteça."
-
+        
     }
   }

--- a/translations/spanish.json
+++ b/translations/spanish.json
@@ -1,14 +1,14 @@
 {
     "$schema": "https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/translation_schema.json",
     "DialogueDictionary": {
-
+  
       // Hint: use «» instead of "".
-
+  
       // Computer GD
       "MAIN COMPUTER: Log access granted, SOLANUM. USER REQUEST: «Last access granted». Calculating...": "ORDENADOR CENTRAL: Acceso concedido, SOLANUM. \nPETICIÓN: «%Último acceso concedido». Calculando...", // use \n here to enter new line
       "MAIN COMPUTER: Last access granted 281,042 years ago. USER = Mallow.": "ORDENADOR CENTRAL: Último acceso concedido hace 281,042 años. \nUSUARIO = Mallow.", // and here
       "Visualizing progress. Deep space anomaly matching all known criteria for the <![CDATA[<color=lightblue>Eye of the universe</color>]]> has been found.": "Visualizando progreso. Una anomalía en el espacio profundo que encaja con el <![CDATA[<color=lightblue>Ojo del universo</color>]]> ha sido encontrada.",
-
+  
       // Computer ATP
       // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutes>]]> MINUTES, <![CDATA[<TimeSeconds>]]> SECONDS AGO: Data received from previous cycles."
       "ASH TWIN PROJECT: Receiving data cycle set up to <![CDATA[<color=orange>22 MINUTES</color>]]>.": "HACE <![CDATA[<TimeMinutes>]]> MINUTOS, <![CDATA[<TimeSeconds>]]> SEGUNDOS: Datos recibidos de ciclos anteriores.",
@@ -17,22 +17,22 @@
       // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
       "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTOS HASTA EL LA TRANSMISIÓN DE FIN DE CICLO.",
       "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "¡ADVERTENCIA! Retirar el núcleo desactivará el <![CDATA[<color=orange>Proyecto gemelo ceniza</color>]]>.",
-
-      // Quantum Moon
+  
+      // Quantum Moon	
       "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: Esto es raro. ¿Dónde estoy? Ahora puedo ver estrellas. Probablemente, encontraré respuestas en el cielo.",
       "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: Es raro, no siento que esté muerta. Quizá sean cosas mí, pero este estado me es familiar. Supongo que tendrá algo que ver con Lumbr...",
-      // Recorder TH
+      // Recorder TH	
       "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Saludos, amigo. Me siento diferente. Es difícil de explicar.",
       "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: No estoy segura de cómo he llegado aquí. Voy a conjeturar que pensar en este sitio ha causado mi desplazamiento. Esto nunca antes me habí pasado.",
       "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: Me has mostrado la extinción de mi clan. Es difícil de digerir. ¿Cuánto tiempo ha pasado desde entonces? Puedo recordar perfectamente escuchar campanas guiándome a la <![CDATA[<color=lightblue>Luna cuántica</color>]]>. Supongo que mi peregrinaje ha llegado a su fin.",
       "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: Nunca había conocido a alguien de tu especie. Es un gran honor hablar contigo, incluso a través de mi grabadora. Tienes mi reconocimiento por entender mi idioma.",
       "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: Me siento afortunada de poder ver a tu raza. Supongo que tenéis el mismo ansia de conocimiento que nosotros. Creo que vi el  <![CDATA[<color=orange>Cañón orbital</color>]]> y está roto. Debemos averiguar qué datos ha logrado recoger.",
-      // Recorder GD
+      // Recorder GD	
       "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: ¡Por fin encontramos el <![CDATA[<color=lightblue>Ojo del universo</color>]]>!. Desearía que mi clan pudiera verlo.",
       "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Aún así, los habitantes del <![CDATA[<color=lightblue>Forastero</color>]]> tenían tecnología que podía entender mejor el <![CDATA[<color=lightblue>Ojo del universo</color>]]>. Tengo que la hipótesis de que el <![CDATA[<color=lightblue>Ojo del universo</color>]]> es peligroso, basándome en su visión. Aún así, su interpretación podría ser errónea.",
       "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: ¿Qué hacemos con este conocimiento sobre el <![CDATA[<color=lightblue>Ojo del universo</color>]]>? Quiero aprender más sobre él y encontrarlo - pero no estoy segura de cómo alcanzarlo. ",
       "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: ¿Estoy equivocada? ¿Está esa estatua mnemónica activa? En este estado, debería estar transmitiendo información al <![CDATA[<color=orange>Proyecto gemelo ceniza</color>]]>.. Echaré un vistazo.",
-      // Recorder ATP
+      // Recorder ATP 	
       "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: ¿Sospecho que ya has visto esto? Nuestro Sol está muriendo... ¿pero tú estás enlazado con una de las estatuas? Ahora lo entiendo. ¿Sabes quién es el que está enlazado con la que hay en el <![CDATA[<color=lightblue>Abismo del gigante</color>]]>?",
       "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: Es una lástima. Hay muchas preguntas que me gustaría hacerte si pudiera comprender tu idioma.",
       "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Quizá, ahora estoy enlazada a una estatua igual que tú. Acabé justo enfrente de una y abrió sus ojos.",
@@ -40,21 +40,21 @@
       "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: Tenía un juguete de bucle temporal cuando era pequeña, pero no sabía muy bien como funcionaba. Quizá visite algunos sitios de <![CDATA[<color=lightblue>mi infancia</color>]]> antes de irme.",
       "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: Si el <![CDATA[<color=lightblue>Sol</color>]]> está mueriendo, debemos estar atrapados. Hipótesis: sería posible sobrevivir si nos alejamos lo suficiente. Esto podría ser una posible solución.",
       "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: Por lo que he visto en tu visión, ahora sé que <![CDATA[<color=orange>La nave</color>]]> está en <![CDATA[<color=lightblue>Espinoscuro</color>]]>. ¿Crees que podría llegar igual que he llegado hasta aquí?",
-      // Recorder ATP 2
+      // Recorder ATP 2	
       "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: Ahora entiendo como funciona el bucle temporal y puedo recordar lo del último bucle.",
       "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz dijo: <![CDATA[<i>«Enviar memorias atrás en el tiempo y viajar al pasado son acciones distintas»</i>]]>.",
       "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: Imagino que esta tecnología sería motivo de celebración en un festival Nomai. Ahora podemos intentar llegar a <![CDATA[<color=orange>La nave</color>]]>. Ahora abriré el núcleo, pero el siguiente bucle será tu turno.",
-      // Recorder BH
+      // Recorder BH	
       "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM:  Este era mi colegio, donde estamos ahora mismo. Aquí, aprendí sobre el universo: estrellas, espacio y tiempo. Supongo que ya no es un lugar seguro. No estoy seguro, pero recuerdo este agujero negro más pequeño.",
       "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: Cuando estudiaba, me gustaba imaginarme el universo colapsar. Conoy me dijo que no pasaría mientras viviéramos. Daba miedo pensarlo. ¿Pero qué pasa después? Quizá se forma algo nuevo.",
       "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: Esto puede no ser seguro, así que he traido este cristal gravitatorio. En este planeta, el espacio y el tiempo están enlazados y limitados.",
       "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: Supongo que este cristal no es completamente estable. Es probable que sea a causa de las fluctuaciones del agujero negro. Ve con cuidado.",
-      // Recorder ET
+      // Recorder ET	
       "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: Aquí pasé mi infancia. Mi hogar y el de mis amigos. Ahora son solo ruinas... es muy triste.",
       "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: Cuando era niña me encantaban estos juguetes. Pyramidion y la nave eran mis favoritos. Esta es sólo una pequeña parte de la herencia cultural Nomai.",
       "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: Esto no es seguro. Puedo escuchar la arena subir.",
       "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: No creo que sean de uso para nadie más. Aléjate, por favor.",
-      // Recorder DB
+      // Recorder DB	
       "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: ¡Es increíble! Los sitemas principales funcionan a pesar de los daños. Estoy segura de que puedo manejarlo.",
       "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: Esta pared muestra mensajes de otros clanes Nomai. Puede parecer raro, pero pensaban que la desaparición de la nave de Escall era un mito.",
       "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: Es increíble <![CDATA[<color=orange>La nave</color>]]> puede recibir mensajes aquí en <![CDATA[<color=lightblue>Espinoscuro</color>]]>. Quizá pueda rastrearlos...",
@@ -63,20 +63,20 @@
       "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "SOLANUM: Pensar en esa posibilidad es excitante, pero no tengo miedo. De hecho, después de todo lo que ha pasado no tengo miedo a nada. Estas son las reglas por las que se rige el universo.",
       "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "SOLANUM: Dos observadores conscientes comenzando un viaje hacia su destino. Puedo notar la incertidumbre crecer. No me sentía así desde que dejé la <![CDATA[<color=lightblue>Luna cuántica</color>]]>.",
       "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "SOLANUM: A partir de ahora, no habrá vuelta atrás. Estoy lista, cualquiera sea tu elección. La decisión es tuya amigo.",
-
-
-
-      // EYE SCENE
+  
+  
+  
+      // EYE SCENE	
       "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Dos observadores conscientes han llegado al Ojo del universo. Acepto tu decisión.",
       "SOLANUM: Would you try to enter it?": "SOLANUM: ¿Podrías intentar introducirlos?",
       "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, la última Nomai viva, ha adquirido consciencia cuántica como resultado de una paradoja. Ha entrado al Ojo conmigo.",
       "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "SOLANUM: Estaba en la <![CDATA[<color=lightblue>Ciudad sin Sol</color>]]>. He conocido a otros Nomai ahí: Laevi, Taget, Lami y otros. Quizá nuestra aventura ha llegado a su final. ",
-
+  
       // Ernesto Quest
-
+  
       // Slate note
       "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "He ido a por ... a por... <![CDATA[<i>setas</i>]]>. ¡No me robes el sitio! Volveré enseguida. Puedes obtener los <![CDATA[<color=orange>Nuevos códigos de lanzamiento</color>]]> en el Observatorio, Corné los ha cambiado en el último minuto.",
-
+  
       // Hornfels
       "Hornfels": "Corné",
       "<![CDATA[<color=orange>Ernesto</color>]]> disappeared!": "<![CDATA[<color=orange>Ernesto</color>]]> ha desaparecido!",
@@ -86,14 +86,14 @@
       "Oh, I'm sorry about that...": "Oh, lo siento...",
       "Poor <![CDATA[<color=orange>Ernesto</color>]]>... Here's your <![CDATA[<color=orange>new launch codes</color>]]>...": "Pobre <![CDATA[<color=orange>Ernesto</color>]]>... Aquí tienes tus <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>...",
       "I just need <![CDATA[<color=orange>new launch codes</color>]]>.": "Necesito los <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>.",
-
-
+  
+  
       // Slate
       "Slate": "Launa",
       "Oh, why are you still here? Did you get the <![CDATA[<color=orange>new launch codes</color>]]> yet?": "Oh, ¿por qué sigues aquí? ¿Tienes ya los <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>?",
       "Is that the anglerfish from the museum?": "¿Es ese el rape del museo?",
       "<![CDATA[<color=orange>Ernesto</color>]]>?! NO!": "¡¿<![CDATA[<color=orange>Ernesto</color>]]>?! ¡NO!",
-
+  
       "The anglerfish from the museum exhibition. Hornfels named it that.": "El rape del museo. Corné lo llamó así.",
       "Okay, you know what? Yes, it is the anglerfish from the museum. I'm fed up with marshmallow. I can't take it anymore.": "Vale, ¿sabes qué? Sí, es el rape del museo. Estoy cansado de malvaviscos, no lo soporto más.",
       "So you decided to eat <![CDATA[<color=orange>Ernesto</color>]]>?! Hornfels said <![CDATA[<color=orange>Ernesto</color>]]> is a friend!": "¡¿Así que decidiste comerte a <![CDATA[<color=orange>Ernesto</color>]]>?! ¡Corné dijo que <![CDATA[<color=orange>Ernesto</color>]]> era su amigo!",
@@ -104,40 +104,40 @@
       "You'll do that for me? Thanks! Just don't tell anyone about <![CDATA[<color=orange>Ernesto</color>]]> alright?": "¿Harías eso por mí? ¡Gracias! Solo no le digas a nadie lo de <![CDATA[<color=orange>Ernesto</color>]]>, ¿vale?",
       "There is no accounting for tastes.": "Sobre gustos no hay nada escrito.",
       "Thank you! Get back within <![CDATA[<i>30 minutes</i>]]> and I'll give you a bite.": "¡Gracias! Vuelve en unos <![CDATA[<i>30 minutos</i>]]> y te dejo un pedazo.",
-
+  
       // Ship dialogue
       "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "Hmm... Este parece un buen lugar para dejar mi linterna proyectora."
-
-
+  
+  
     },
       "UIDictionary": {
-
+  
           "Quantum Consciousness": "Consciencia cuántica",
           "Solanum": "Solanum",
           "GloamingGalaxy": "Galaxia Ocaso",
           "THE_VISION_NEW_LAUNCH_CODES": "Nuevos códigos de lanzamiento: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-
+  
           "THE_VISION_TO_BE_CONTINUED": "SOLANUM Y TÚ ESCAPÁIS MÁS ALLÁ DEL ALCANCE DE LA SUPERNOVA Y CONOCÉIS A LOS NOMAI DE ROCANEGRA. \nJUNTOS VEIS CÓMO LAS ESTRELLAS SE APAGAN.",
           "THE_VISION_POPUP": "¡Gracias por descargar «The Vision»! Mira los registros de tu nave para comenzar."
-
+  
       },
       "ShipLogDictionary": {
-
+  
           // Brittle Hollow
           "Solanum in the School Ruins": "Solanum en las ruinas escolares",
           "Solanum on Brittle Hollow": "Solanum en Hondonada Frágil",
           "I can hear Solanum's signal coming from Brittle Hollow.": "Puedo escuchar la señal de Solanum saliendo de Hondonada Frágil.",
           "I found Solanum in the School.": "He encontrado a Solanum en el colegio.",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "Solanum dijo que aquí fue al colegio. También mencionó que el agujero negro era más pequeño. Tomo un cristal gravitacional para no caerse.",
-
+  
           // CaveTwin_Body
           "Solanum in the Sunless City": "Solanum en la Ciudad sin Sol",
           "I can hear Solanum's signal coming from the Sunless City.": "Puedo escuchar la señal de Solanum saliendo de la Ciudad sin Sol.",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "He encontrado a Solanum en la Ciudad sin Sol. Estaba en su casa en el distrito del Templo del Ojo.",
-          // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
+          // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Está triste por ver la Ciudad sin Sol en ruinas. Me contó detalles acerca de su infancia.",
-
-
+  
+  
           // DB_VesselBody
           "Solanum on the Vessel": "Solanum on the Vessel",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "Solanum quiere intentar llegar a La nvae. ¿Es posible para ella acceder a Espinoscuro?",
@@ -147,18 +147,18 @@
           "New coordinates": "Nuevas coordenadas",
           // "I found new coordinates to another Galaxy. We can use the Warp Core from the Ash Twin Project to warp. There will be no turning back once I warp. Am I ready to do this?": "I found new coordinates to another Galaxy. We can use the Warp Core from the Ash Twin Project to warp. There will be no turning back once I warp. Am I ready to do this?",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "He encontrado las coordenadas a la Galaxia Ocas. Podemos usar el núcleo del proyecto Gemelo Ceniza para ir. No habrá vuelta atrás. ¿Estoy listo?",
-
-
-
-
+  
+  
+  
+  
           // Giants Deep
           "Solanum on Giant's Deep": "Solanum en el Abismo del Gigante",
           "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "Solanum quiere visitar el Abismo del Gigante, pero también estará por Lumbre.",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "He encontrado a Solanum mirando los registros de la sonda. Nunca había visto ordenadores Nomai con semejante brillo. Está accediendo al ordenador central para ver cuánto tiempo ha pasado.",
           // "Solanum feels sad about the Eye of the Universe. Since childhood, she knew - the Eye has no wishes at all. It's not surprising that she don't want to know anything more about it. There was an active Memory Statue here that caught her eye.": "Solanum feels sad about the Eye of the Universe. Since childhood, she knew - the Eye has no wishes at all. It's not surprising that she don't want to know anything more about it. There was an active Memory Statue here that caught her eye.",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanum está observando el Ojo y la visión de los habitantes del Forastero. También ha identificado una estatua mnemónica.",
-
-
+  
+  
           // Quantum Moon
           "Solanum on Quantum Moon": "Solanum en la Luna Cuántica",
           "What if..?": "¿Y si..?",
@@ -170,13 +170,13 @@
           "There are some new inscriptions left very recently": "Hay inscripciones recientes",
           // "It must be very strange to see your own dead body. I'm not surprised Solanum that wants to leave this place as soon as possible. She took her recorder and vanished on mentioning Timber Hearth.": "It must be very strange to see your own dead body. I'm not surprised Solanum that wants to leave this place as soon as possible. She took her recorder and vanished on mentioning Timber Hearth.",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "El mensaje de Solanum se cortó abruptamente tras mencionar Lumbre.",
-
-
+  
+  
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "Linterna proyectora del Laboratorio Dañado",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "Creo que hay una linterna proyectora en el Laboratorio Dañado. Me pregunto si todavía funciona.",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "He encontrado la linterna proyectora. Sus llamas funcionan incluso en el espacio donde no hay oxígeno.",
-
+  
           // Timber Hearth
           "Solanum on Timber Hearth": "Solanum en Lumbre",
           "Is Solanum on Timber Hearth?": "¿Está Solanum en Lumbre?",
@@ -185,9 +185,9 @@
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum ha aparecido en Lumbre cerca del pueblo. Parece estar observando a los lumbreanos.",
           //"According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.": "According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "Solanum pensó en Lumbre y apareció allí. Quiere saber más del Módulo de Rastreo de Sondas en el Abismo del Gigante.",
-
-
-
+  
+  
+  
           // Quantum Consciousness
           "Quantum Consciousness": "Consciencia Cuántica",
           "I've discovered strange frequency called Quantum Consciousness.": "He descubierto una frecuencia extraña llamada Consciencia Cuántica.",
@@ -197,23 +197,23 @@
           // "Quantum Consciousness somehow has the ability to exist in a multiple places at the same time. According to Solanum, she is only capable of appearing at certain locations by thinking about them. Hypothesis: she can appear only in known places.": "Quantum Consciousness somehow has the ability to exist in a multiple places at the same time. According to Solanum, she is only capable of appearing at certain locations by thinking about them. Hypothesis: she can appear only in known places.",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "Otra propiedad notable de la Consciencia Cuántica - partículas alrededor de la cabeza del sujeto. Nota: las otras reglas cuánticas no aplican a la Consciencia Cuántica.",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "El poseedor de la Consciencia Cuántica de alguna forma tiene la capacidad de existir en múltiples sitios al mismo tiempo. Según Solanum, ella es capaz de aparecer en varios sitios sólo con pensar en ellos. Probablemente, sólo pueda aparecer en sitios que ya conocía.",
-
-
-
+  
+  
+  
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "Solanum dentro del Proyecto Gemelo Ceniza",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "Solanum quiere comprobar el panel de control del bucle temporal. Estará dentro del Proyecto Gemelo Ceniza.",
           "Solanum is already here. She observing the time loop ring's logs.": "Solanum ya está aquí. Está mirando los registros.",
           // "Solanum just realized I'm in the time loop and that our Sun will supernova soon. Using the charged warp core, we might be able to escape. Seems like we will meet again inside the Vessel.": "Solanum just realized I'm in the time loop and that our Sun will supernova soon. Using the charged warp core, we might be able to escape. It seems like we will meet again inside the Vessel.",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": "Ahora ya sabe del bucle temporal y que nuestro Sol se convertirá en supernova. Solanum quiere ir a La Nave, pero también quiere visitar lugares de su infancia. Podría intentar encontrarla en La Nave, o en otros lugares.",
-
+  
           "Paired Statue": "Estatua enlazada",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "Solanum pasó por delante de una estatua sin enlazar en el Proyecto Gemelo Ceniza. Ahora ella también está atrapada en el bucle temporal.",
           // "Now that Solanum knows how time loop reset works, we will try reach the Vessel.": "Now that Solanum knows how time loop reset works, we will try reach the Vessel.",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Durante el último ciclo, Solanum no sabía cómo funcionaba el bucle temporal. Ahora lo tiene claro y quiere ir a La Nave.",
-
-
-          // Ernesto Quest
+  
+  
+          // Ernesto Quest        
           "Where is Ernesto?": "¿Dónde está Ernesto?",
           "Seriously, how could an anglerfish just disappear?": "En serio, ¿cómo puede haber desaparecido un rape?",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Corné dice que el rape «Ernesto» ha desaparecido.",
@@ -221,6 +221,6 @@
           "I found Ernesto": "He encontrado a Ernesto",
           "I found Slate with Ernesto. He's cooking him on campfire.": "Encontré a Launa con Ernesto. Lo está cocinando.",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Launa está cansado de malvaviscos, así que ha decidido cocinar a Ernesto. Dice que estará listo en 30 minutos. No necesito intervenir, ya que el bucle temporal se reiniciará antes de que eso pase."
-
+  
       }
   }

--- a/translations/spanish.json
+++ b/translations/spanish.json
@@ -1,14 +1,14 @@
 {
     "$schema": "https://raw.githubusercontent.com/xen-42/outer-wilds-new-horizons/main/NewHorizons/Schemas/translation_schema.json",
     "DialogueDictionary": {
-  
+
       // Hint: use «» instead of "".
-  
+
       // Computer GD
       "MAIN COMPUTER: Log access granted, SOLANUM. USER REQUEST: «Last access granted». Calculating...": "ORDENADOR CENTRAL: Acceso concedido, SOLANUM. \nPETICIÓN: «%Último acceso concedido». Calculando...", // use \n here to enter new line
       "MAIN COMPUTER: Last access granted 281,042 years ago. USER = Mallow.": "ORDENADOR CENTRAL: Último acceso concedido hace 281,042 años. \nUSUARIO = Mallow.", // and here
       "Visualizing progress. Deep space anomaly matching all known criteria for the <![CDATA[<color=lightblue>Eye of the universe</color>]]> has been found.": "Visualizando progreso. Una anomalía en el espacio profundo que encaja con el <![CDATA[<color=lightblue>Ojo del universo</color>]]> ha sido encontrada.",
-  
+
       // Computer ATP
       // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutes>]]> MINUTES, <![CDATA[<TimeSeconds>]]> SECONDS AGO: Data received from previous cycles."
       "ASH TWIN PROJECT: Receiving data cycle set up to <![CDATA[<color=orange>22 MINUTES</color>]]>.": "HACE <![CDATA[<TimeMinutes>]]> MINUTOS, <![CDATA[<TimeSeconds>]]> SEGUNDOS: Datos recibidos de ciclos anteriores.",
@@ -17,22 +17,22 @@
       // Here ↓ translate this (with same CDATA things): "<![CDATA[<TimeMinutesRemaining>]]> MINUTES UNTIL END-OF-CYCLE TRANSMISSION."
       "ALL SYSTEMS ARE <![CDATA[<color=orange>STABLE</color>]]>": "<![CDATA[<TimeMinutesRemaining>]]> MINUTOS HASTA EL LA TRANSMISIÓN DE FIN DE CICLO.",
       "WARNING! Removing the core will disable the <![CDATA[<color=orange>Ash Twin Project</color>]]>.": "¡ADVERTENCIA! Retirar el núcleo desactivará el <![CDATA[<color=orange>Proyecto gemelo ceniza</color>]]>.",
-  
-      // Quantum Moon	
+
+      // Quantum Moon
       "SOLANUM: This is strange. Where am I? I see stars now. Likely, I will find the answers in the sky above.": "SOLANUM: Esto es raro. ¿Dónde estoy? Ahora puedo ver estrellas. Probablemente, encontraré respuestas en el cielo.",
       "SOLANUM: It's strange, I don't feel dead. Perhaps this is my past uncertainty. This place looks familiar. I assume it's a state of Timber Hea...": "SOLANUM: Es raro, no siento que esté muerta. Quizá sean cosas mí, pero este estado me es familiar. Supongo que tendrá algo que ver con Lumbr...",
-      // Recorder TH	
+      // Recorder TH
       "SOLANUM: Greetings, friend. I feel different, but it's hard to explain.": "SOLANUM: Saludos, amigo. Me siento diferente. Es difícil de explicar.",
       "SOLANUM: I’m unsure how I arrived here. I would conjecture that the thought of this place somehow forced my displacement. This has never happened to me before.": "SOLANUM: No estoy segura de cómo he llegado aquí. Voy a conjeturar que pensar en este sitio ha causado mi desplazamiento. Esto nunca antes me habí pasado.",
       "SOLANUM: You showed me the death of my clan. It's very hard to comprehend. How long do you think it's been since then? I clearly remember Bells guiding me on a pilgrimage to the <![CDATA[<color=lightblue>Quantum Moon</color>]]>. I suppose my pilgrimage has reached its end.": "SOLANUM: Me has mostrado la extinción de mi clan. Es difícil de digerir. ¿Cuánto tiempo ha pasado desde entonces? Puedo recordar perfectamente escuchar campanas guiándome a la <![CDATA[<color=lightblue>Luna cuántica</color>]]>. Supongo que mi peregrinaje ha llegado a su fin.",
       "SOLANUM: I’ve never met one of your kind before. It’s a great honor to speak with you, even by recorder. You have my gratitude for understanding my language.": "SOLANUM: Nunca había conocido a alguien de tu especie. Es un gran honor hablar contigo, incluso a través de mi grabadora. Tienes mi reconocimiento por entender mi idioma.",
       "SOLANUM: I am glad to observe your race. I imagine you have the same thirst for knowledge as ours. I think I saw the <![CDATA[<color=orange>Orbital Cannon</color>]]> and it's broken. It's time to find out what data it managed to collect.": "SOLANUM: Me siento afortunada de poder ver a tu raza. Supongo que tenéis el mismo ansia de conocimiento que nosotros. Creo que vi el  <![CDATA[<color=orange>Cañón orbital</color>]]> y está roto. Debemos averiguar qué datos ha logrado recoger.",
-      // Recorder GD	
+      // Recorder GD
       "SOLANUM: We've finally found the <![CDATA[<color=lightblue>Eye of the universe</color>]]>. I wish my clan could see this.": "SOLANUM: ¡Por fin encontramos el <![CDATA[<color=lightblue>Ojo del universo</color>]]>!. Desearía que mi clan pudiera verlo.",
       "SOLANUM: Still, strangers from another star system had important knowledge. They had technology that could understand the <![CDATA[<color=lightblue>Eye</color>]]> better. I have a hypothesis that the <![CDATA[<color=lightblue>Eye</color>]]> is dangerous, based on their vision. However, their interpretation could be wrong.": "SOLANUM: Aún así, los habitantes del <![CDATA[<color=lightblue>Forastero</color>]]> tenían tecnología que podía entender mejor el <![CDATA[<color=lightblue>Ojo del universo</color>]]>. Tengo que la hipótesis de que el <![CDATA[<color=lightblue>Ojo del universo</color>]]> es peligroso, basándome en su visión. Aún así, su interpretación podría ser errónea.",
       "SOLANUM: What do we do with this knowledge about the <![CDATA[<color=lightblue>Eye</color>]]>? I want to learn about it, and I want to find it - but I'm not sure how to reach it. ": "SOLANUM: ¿Qué hacemos con este conocimiento sobre el <![CDATA[<color=lightblue>Ojo del universo</color>]]>? Quiero aprender más sobre él y encontrarlo - pero no estoy segura de cómo alcanzarlo. ",
       "SOLANUM: Am I wrong? Is that Memory Statue active? In this activated state, it should be transmitting data to the <![CDATA[<color=orange>Ash Twin Project</color>]]>.. I'll take a look at it.": "SOLANUM: ¿Estoy equivocada? ¿Está esa estatua mnemónica activa? En este estado, debería estar transmitiendo información al <![CDATA[<color=orange>Proyecto gemelo ceniza</color>]]>.. Echaré un vistazo.",
-      // Recorder ATP 	
+      // Recorder ATP
       "SOLANUM: I suspect you have seen this? Our Sun is dying... but you are paired with one of the statues? Now I understand. Do you know who else is paired at <![CDATA[<color=lightblue>Giant’s Deep</color>]]>?": "SOLANUM: ¿Sospecho que ya has visto esto? Nuestro Sol está muriendo... ¿pero tú estás enlazado con una de las estatuas? Ahora lo entiendo. ¿Sabes quién es el que está enlazado con la que hay en el <![CDATA[<color=lightblue>Abismo del gigante</color>]]>?",
       "SOLANUM: It's a pity. There are many questions I would ask if I could comprehend your language.": "SOLANUM: Es una lástima. Hay muchas preguntas que me gustaría hacerte si pudiera comprender tu idioma.",
       "SOLANUM: Perhaps, now I am linked to the Statue same way as you. I ended up right in front of that nearby statue and it opened its eyes.": "SOLANUM: Quizá, ahora estoy enlazada a una estatua igual que tú. Acabé justo enfrente de una y abrió sus ojos.",
@@ -40,21 +40,21 @@
       "SOLANUM: I had a time loop toy when I was a child, but I'm unsure how the time loop itself functioned. I may want to visit my <![CDATA[<color=lightblue>childhood places</color>]]> first, before departing.": "SOLANUM: Tenía un juguete de bucle temporal cuando era pequeña, pero no sabía muy bien como funcionaba. Quizá visite algunos sitios de <![CDATA[<color=lightblue>mi infancia</color>]]> antes de irme.",
       "SOLANUM: If the <![CDATA[<color=lightblue>Sun</color>]]> is dying, we must be trapped. Hypothesis: it is possible to survive, if we could get far enough. This is a possible solution.": "SOLANUM: Si el <![CDATA[<color=lightblue>Sol</color>]]> está mueriendo, debemos estar atrapados. Hipótesis: sería posible sobrevivir si nos alejamos lo suficiente. Esto podría ser una posible solución.",
       "SOLANUM: From your vision, I now know the <![CDATA[<color=orange>Vessel</color>]]> is in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Do you think I could reach it, like how I reached this place?": "SOLANUM: Por lo que he visto en tu visión, ahora sé que <![CDATA[<color=orange>La nave</color>]]> está en <![CDATA[<color=lightblue>Espinoscuro</color>]]>. ¿Crees que podría llegar igual que he llegado hasta aquí?",
-      // Recorder ATP 2	
+      // Recorder ATP 2
       "SOLANUM: I understand how the time loop works now and I remember everything from previous cycle.": "SOLANUM: Ahora entiendo como funciona el bucle temporal y puedo recordar lo del último bucle.",
       "SOLANUM: Daz said: <![CDATA[<i>«Sending memories back in time and going back in time physically are two different actions»</i>]]>.": "SOLANUM: Daz dijo: <![CDATA[<i>«Enviar memorias atrás en el tiempo y viajar al pasado son acciones distintas»</i>]]>.",
       "SOLANUM: I can imagine such technology would be worthy of celebration at the Nomai festival. Now we can try to get to <![CDATA[<color=orange>the Vessel</color>]]>. I'll open the core once again, but next loop it's your turn.": "SOLANUM: Imagino que esta tecnología sería motivo de celebración en un festival Nomai. Ahora podemos intentar llegar a <![CDATA[<color=orange>La nave</color>]]>. Ahora abriré el núcleo, pero el siguiente bucle será tu turno.",
-      // Recorder BH	
+      // Recorder BH
       "SOLANUM:  This was my school, where we both are standing. Here, I learned about the universe: stars, space, and time. I assume it's not a safe place anymore. I'm unsure, but I remember the black hole being smaller.": "SOLANUM:  Este era mi colegio, donde estamos ahora mismo. Aquí, aprendí sobre el universo: estrellas, espacio y tiempo. Supongo que ya no es un lugar seguro. No estoy seguro, pero recuerdo este agujero negro más pequeño.",
       "SOLANUM: As a student, I was imagining the universe collapse. Conoy told me it wouldn't happen in our lifetimes. That was scary to think about. But what comes after? Perhaps it forms something new.": "SOLANUM: Cuando estudiaba, me gustaba imaginarme el universo colapsar. Conoy me dijo que no pasaría mientras viviéramos. Daba miedo pensarlo. ¿Pero qué pasa después? Quizá se forma algo nuevo.",
       "SOLANUM: It might be unsafe here, so I brought this gravity crystal. On this planet, space and time are inextricably linked and limited.": "SOLANUM: Esto puede no ser seguro, así que he traido este cristal gravitatorio. En este planeta, el espacio y el tiempo están enlazados y limitados.",
       "SOLANUM: I suppose this crystal is not completely stable. It's probably because of the black hole's increasing fluctuations. Be careful here.": "SOLANUM: Supongo que este cristal no es completamente estable. Es probable que sea a causa de las fluctuaciones del agujero negro. Ve con cuidado.",
-      // Recorder ET	
+      // Recorder ET
       "SOLANUM: I spent my childhoom here. Home for me and my family and friends. The city lies in ruins now... it is sad to see it like this.": "SOLANUM: Aquí pasé mi infancia. Mi hogar y el de mis amigos. Ahora son solo ruinas... es muy triste.",
       "SOLANUM: When I was a child, I loved these toys. Pyramidion and shuttle were both my favorites. This is only a small part of the Nomai cultural heritage.": "SOLANUM: Cuando era niña me encantaban estos juguetes. Pyramidion y la nave eran mis favoritos. Esta es sólo una pequeña parte de la herencia cultural Nomai.",
       "SOLANUM: It's unsafe here, I think. I can hear the sand rising.": "SOLANUM: Esto no es seguro. Puedo escuchar la arena subir.",
       "SOLANUM: I don't think they'll be of any use to anyone else. Stay back, please.": "SOLANUM: No creo que sean de uso para nadie más. Aléjate, por favor.",
-      // Recorder DB	
+      // Recorder DB
       "SOLANUM: That's incredible! The main systems work despite the damage. I'm sure I can handle this.": "SOLANUM: ¡Es increíble! Los sitemas principales funcionan a pesar de los daños. Estoy segura de que puedo manejarlo.",
       "SOLANUM: This wall shows incoming messages from other Nomai clans. It may be strange, but they believe Escall's Vessel Disappearance was a myth.": "SOLANUM: Esta pared muestra mensajes de otros clanes Nomai. Puede parecer raro, pero pensaban que la desaparición de la nave de Escall era un mito.",
       "SOLANUM: It's incredible <![CDATA[<color=orange>the Vessel</color>]]> can receive these messages here in <![CDATA[<color=lightblue>Dark Bramble</color>]]>. Perhaps I can trace them back...": "SOLANUM: Es increíble <![CDATA[<color=orange>La nave</color>]]> puede recibir mensajes aquí en <![CDATA[<color=lightblue>Espinoscuro</color>]]>. Quizá pueda rastrearlos...",
@@ -63,20 +63,20 @@
       "SOLANUM: Thinking of such a possibility is exciting. But I do not fear this. In fact, after all that has happened, I have no fear at all. These are simply the laws by which the universe lives.": "SOLANUM: Pensar en esa posibilidad es excitante, pero no tengo miedo. De hecho, después de todo lo que ha pasado no tengo miedo a nada. Estas son las reglas por las que se rige el universo.",
       "SOLANUM: Two conscious observers starting a journey towards destiny. I can feel the uncertainty grow enormously. It hasn't felt this strong since I left the <![CDATA[<color=lightblue>Quantum Moon</color>]]>.": "SOLANUM: Dos observadores conscientes comenzando un viaje hacia su destino. Puedo notar la incertidumbre crecer. No me sentía así desde que dejé la <![CDATA[<color=lightblue>Luna cuántica</color>]]>.",
       "SOLANUM: There will be no turning back. I am ready for whatever is next, friend. The decision is yours.": "SOLANUM: A partir de ahora, no habrá vuelta atrás. Estoy lista, cualquiera sea tu elección. La decisión es tuya amigo.",
-  
-  
-  
-      // EYE SCENE	
+
+
+
+      // EYE SCENE
       "SOLANUM: Two conscious observers have reached Eye of the universe. I accept your decision.": "SOLANUM: Dos observadores conscientes han llegado al Ojo del universo. Acepto tu decisión.",
       "SOLANUM: Would you try to enter it?": "SOLANUM: ¿Podrías intentar introducirlos?",
       "Solanum, the last Nomai alive, acquired Quantum Consciousness as a result of a paradox. She entered the Eye with me.": "Solanum, la última Nomai viva, ha adquirido consciencia cuántica como resultado de una paradoja. Ha entrado al Ojo conmigo.",
       "I was in the <![CDATA[<color=lightblue>Sunless City</color>]]>. I met other Nomai there: Laevi, Tage, Lami and others. Perhaps our journey has reached its end. ": "SOLANUM: Estaba en la <![CDATA[<color=lightblue>Ciudad sin Sol</color>]]>. He conocido a otros Nomai ahí: Laevi, Taget, Lami y otros. Quizá nuestra aventura ha llegado a su final. ",
-  
+
       // Ernesto Quest
-  
+
       // Slate note
       "I went for ... for ... <![CDATA[<i>mushrooms</i>]]>. Don't take my place! I'll be back soon. Get <![CDATA[<color=orange>new launch codes</color>]]> at the Observatory, Hornfels changed them at the last minute.": "He ido a por ... a por... <![CDATA[<i>setas</i>]]>. ¡No me robes el sitio! Volveré enseguida. Puedes obtener los <![CDATA[<color=orange>Nuevos códigos de lanzamiento</color>]]> en el Observatorio, Corné los ha cambiado en el último minuto.",
-  
+
       // Hornfels
       "Hornfels": "Corné",
       "<![CDATA[<color=orange>Ernesto</color>]]> disappeared!": "<![CDATA[<color=orange>Ernesto</color>]]> ha desaparecido!",
@@ -86,14 +86,14 @@
       "Oh, I'm sorry about that...": "Oh, lo siento...",
       "Poor <![CDATA[<color=orange>Ernesto</color>]]>... Here's your <![CDATA[<color=orange>new launch codes</color>]]>...": "Pobre <![CDATA[<color=orange>Ernesto</color>]]>... Aquí tienes tus <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>...",
       "I just need <![CDATA[<color=orange>new launch codes</color>]]>.": "Necesito los <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>.",
-  
-  
+
+
       // Slate
       "Slate": "Launa",
       "Oh, why are you still here? Did you get the <![CDATA[<color=orange>new launch codes</color>]]> yet?": "Oh, ¿por qué sigues aquí? ¿Tienes ya los <![CDATA[<color=orange>nuevos códigos de lanzamiento</color>]]>?",
       "Is that the anglerfish from the museum?": "¿Es ese el rape del museo?",
       "<![CDATA[<color=orange>Ernesto</color>]]>?! NO!": "¡¿<![CDATA[<color=orange>Ernesto</color>]]>?! ¡NO!",
-  
+
       "The anglerfish from the museum exhibition. Hornfels named it that.": "El rape del museo. Corné lo llamó así.",
       "Okay, you know what? Yes, it is the anglerfish from the museum. I'm fed up with marshmallow. I can't take it anymore.": "Vale, ¿sabes qué? Sí, es el rape del museo. Estoy cansado de malvaviscos, no lo soporto más.",
       "So you decided to eat <![CDATA[<color=orange>Ernesto</color>]]>?! Hornfels said <![CDATA[<color=orange>Ernesto</color>]]> is a friend!": "¡¿Así que decidiste comerte a <![CDATA[<color=orange>Ernesto</color>]]>?! ¡Corné dijo que <![CDATA[<color=orange>Ernesto</color>]]> era su amigo!",
@@ -104,40 +104,40 @@
       "You'll do that for me? Thanks! Just don't tell anyone about <![CDATA[<color=orange>Ernesto</color>]]> alright?": "¿Harías eso por mí? ¡Gracias! Solo no le digas a nadie lo de <![CDATA[<color=orange>Ernesto</color>]]>, ¿vale?",
       "There is no accounting for tastes.": "Sobre gustos no hay nada escrito.",
       "Thank you! Get back within <![CDATA[<i>30 minutes</i>]]> and I'll give you a bite.": "¡Gracias! Vuelve en unos <![CDATA[<i>30 minutos</i>]]> y te dejo un pedazo.",
-  
+
       // Ship dialogue
       "Hmm... This seems like a good place for a vision torch! I can put it here if needed.": "Hmm... Este parece un buen lugar para dejar mi linterna proyectora."
-  
-  
+
+
     },
       "UIDictionary": {
-  
+
           "Quantum Consciousness": "Consciencia cuántica",
           "Solanum": "Solanum",
           "GloamingGalaxy": "Galaxia Ocaso",
           "THE_VISION_NEW_LAUNCH_CODES": "Nuevos códigos de lanzamiento: --|-..|-.--|-.", // New launch codes: --|-..|-.--|-.
-  
+
           "THE_VISION_TO_BE_CONTINUED": "SOLANUM Y TÚ ESCAPÁIS MÁS ALLÁ DEL ALCANCE DE LA SUPERNOVA Y CONOCÉIS A LOS NOMAI DE ROCANEGRA. \nJUNTOS VEIS CÓMO LAS ESTRELLAS SE APAGAN.",
           "THE_VISION_POPUP": "¡Gracias por descargar «The Vision»! Mira los registros de tu nave para comenzar."
-  
+
       },
       "ShipLogDictionary": {
-  
+
           // Brittle Hollow
           "Solanum in the School Ruins": "Solanum en las ruinas escolares",
           "Solanum on Brittle Hollow": "Solanum en Hondonada Frágil",
           "I can hear Solanum's signal coming from Brittle Hollow.": "Puedo escuchar la señal de Solanum saliendo de Hondonada Frágil.",
           "I found Solanum in the School.": "He encontrado a Solanum en el colegio.",
           "Solanum said this is where she went to school. She also mentioned that the black hole used to be much smaller. She took a gravity crystal to avoid falling.": "Solanum dijo que aquí fue al colegio. También mencionó que el agujero negro era más pequeño. Tomo un cristal gravitacional para no caerse.",
-  
+
           // CaveTwin_Body
           "Solanum in the Sunless City": "Solanum en la Ciudad sin Sol",
           "I can hear Solanum's signal coming from the Sunless City.": "Puedo escuchar la señal de Solanum saliendo de la Ciudad sin Sol.",
           "I found Solanum in the Sunless City. She is staying at her home in the Eye Temple district.": "He encontrado a Solanum en la Ciudad sin Sol. Estaba en su casa en el distrito del Templo del Ojo.",
-          // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",        
+          // "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.": "Solanum feels sad about the Nomai's blind faith in the Eye. She destroyed her old toys.",
           "She feels sad seeing the Sunless City in ruins. Solanum told a little about her childhood.": "Está triste por ver la Ciudad sin Sol en ruinas. Me contó detalles acerca de su infancia.",
-  
-  
+
+
           // DB_VesselBody
           "Solanum on the Vessel": "Solanum on the Vessel",
           "Solanum wants to try to get to the Vessel. Is it possible for her to get inside Dark Bramble?": "Solanum quiere intentar llegar a La nvae. ¿Es posible para ella acceder a Espinoscuro?",
@@ -147,18 +147,18 @@
           "New coordinates": "Nuevas coordenadas",
           // "I found new coordinates to another Galaxy. We can use the Warp Core from the Ash Twin Project to warp. There will be no turning back once I warp. Am I ready to do this?": "I found new coordinates to another Galaxy. We can use the Warp Core from the Ash Twin Project to warp. There will be no turning back once I warp. Am I ready to do this?",
           "I found the coordinates to the Gloaming Galaxy. We can use the warp core from the Ash Twin Project to warp. There will be no turning back. Am I ready to do this?": "He encontrado las coordenadas a la Galaxia Ocas. Podemos usar el núcleo del proyecto Gemelo Ceniza para ir. No habrá vuelta atrás. ¿Estoy listo?",
-  
-  
-  
-  
+
+
+
+
           // Giants Deep
           "Solanum on Giant's Deep": "Solanum en el Abismo del Gigante",
           "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "Solanum quiere visitar el Abismo del Gigante, pero también estará por Lumbre.",
           "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "He encontrado a Solanum mirando los registros de la sonda. Nunca había visto ordenadores Nomai con semejante brillo. Está accediendo al ordenador central para ver cuánto tiempo ha pasado.",
           // "Solanum feels sad about the Eye of the Universe. Since childhood, she knew - the Eye has no wishes at all. It's not surprising that she don't want to know anything more about it. There was an active Memory Statue here that caught her eye.": "Solanum feels sad about the Eye of the Universe. Since childhood, she knew - the Eye has no wishes at all. It's not surprising that she don't want to know anything more about it. There was an active Memory Statue here that caught her eye.",
           "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanum está observando el Ojo y la visión de los habitantes del Forastero. También ha identificado una estatua mnemónica.",
-  
-  
+
+
           // Quantum Moon
           "Solanum on Quantum Moon": "Solanum en la Luna Cuántica",
           "What if..?": "¿Y si..?",
@@ -170,24 +170,24 @@
           "There are some new inscriptions left very recently": "Hay inscripciones recientes",
           // "It must be very strange to see your own dead body. I'm not surprised Solanum that wants to leave this place as soon as possible. She took her recorder and vanished on mentioning Timber Hearth.": "It must be very strange to see your own dead body. I'm not surprised Solanum that wants to leave this place as soon as possible. She took her recorder and vanished on mentioning Timber Hearth.",
           "Solanum's message abruptly stopped while mentioning Timber Hearth.": "El mensaje de Solanum se cortó abruptamente tras mencionar Lumbre.",
-  
-  
+
+
           // Ring World (Stranger)
           "Vision Torch in Damaged Laboratory": "Linterna proyectora del Laboratorio Dañado",
           "I believe there is a vision torch somewhere in the Damaged Laboratory. I wonder if it's still working.": "Creo que hay una linterna proyectora en el Laboratorio Dañado. Me pregunto si todavía funciona.",
           "I found that vision torch. Its flames still work even in space where there is no oxygen.": "He encontrado la linterna proyectora. Sus llamas funcionan incluso en el espacio donde no hay oxígeno.",
-  
+
           // Timber Hearth
           "Solanum on Timber Hearth": "Solanum en Lumbre",
           "Is Solanum on Timber Hearth?": "¿Está Solanum en Lumbre?",
-          "New quantum frequency": "Nueva frecuencia cuántica",
+          "New quantum frequency?": "Nueva frecuencia cuántica?",
           "Solanum's message was interrupted when she mentioned Timber Hearth. Maybe she is there?": "El mensaje de Solanum se interrumpió cuando hablaba de Lumbre. ¿Estará allí?",
           "Solanum somehow appeared on Timber Hearth near the Village. It seems like she is observing the Hearthians.": "Solanum ha aparecido en Lumbre cerca del pueblo. Parece estar observando a los lumbreanos.",
           //"According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.": "According to her recorder, she just thought of Timber Hearth and appeared there. That could be explainable with my new Quantum Rule. Solanum told me about the Sun Station, she apologized, but that's ok. Solanum would also like to know more about the Probe Tracking Module inside Giant's Deep.",
           "Solanum thought of Timber Hearth, then appeared there. She wants to know more about the Probe Tracking Module inside Giant's Deep.": "Solanum pensó en Lumbre y apareció allí. Quiere saber más del Módulo de Rastreo de Sondas en el Abismo del Gigante.",
-  
-  
-  
+
+
+
           // Quantum Consciousness
           "Quantum Consciousness": "Consciencia Cuántica",
           "I've discovered strange frequency called Quantum Consciousness.": "He descubierto una frecuencia extraña llamada Consciencia Cuántica.",
@@ -197,23 +197,23 @@
           // "Quantum Consciousness somehow has the ability to exist in a multiple places at the same time. According to Solanum, she is only capable of appearing at certain locations by thinking about them. Hypothesis: she can appear only in known places.": "Quantum Consciousness somehow has the ability to exist in a multiple places at the same time. According to Solanum, she is only capable of appearing at certain locations by thinking about them. Hypothesis: she can appear only in known places.",
           "Another noticeable feature of Quantum Consciousness - particles near the possessor's head. Note: it appears that the other quantum rules do not apply to a Quantum Consciousness.": "Otra propiedad notable de la Consciencia Cuántica - partículas alrededor de la cabeza del sujeto. Nota: las otras reglas cuánticas no aplican a la Consciencia Cuántica.",
           "A possessor of Quantum Consciousness somehow has the ability to exist in multiple places at once. According to Solanum, she is capable of appearing at certain locations by thinking about them. Probably, she can appear only in places she knows.": "El poseedor de la Consciencia Cuántica de alguna forma tiene la capacidad de existir en múltiples sitios al mismo tiempo. Según Solanum, ella es capaz de aparecer en varios sitios sólo con pensar en ellos. Probablemente, sólo pueda aparecer en sitios que ya conocía.",
-  
-  
-  
+
+
+
           // ATP Time Loop Ring
           "Solanum inside Ash Twin Project": "Solanum dentro del Proyecto Gemelo Ceniza",
           "Solanum wants to check the time loop control panel. I might find her inside the Ash Twin Project.": "Solanum quiere comprobar el panel de control del bucle temporal. Estará dentro del Proyecto Gemelo Ceniza.",
           "Solanum is already here. She observing the time loop ring's logs.": "Solanum ya está aquí. Está mirando los registros.",
           // "Solanum just realized I'm in the time loop and that our Sun will supernova soon. Using the charged warp core, we might be able to escape. Seems like we will meet again inside the Vessel.": "Solanum just realized I'm in the time loop and that our Sun will supernova soon. Using the charged warp core, we might be able to escape. It seems like we will meet again inside the Vessel.",
           "Now she knows about the time loop and that our Sun will soon go supernova. Solanum wants to reach the Vessel, but she also wants to revisit her childhood places. I can try to find her on the Vessel, or somewhere else.": "Ahora ya sabe del bucle temporal y que nuestro Sol se convertirá en supernova. Solanum quiere ir a La Nave, pero también quiere visitar lugares de su infancia. Podría intentar encontrarla en La Nave, o en otros lugares.",
-  
+
           "Paired Statue": "Estatua enlazada",
           "Solanum just happened to pass right by the unpaired statue inside the Ash Twin Project. Now she's stuck in the time loop too.": "Solanum pasó por delante de una estatua sin enlazar en el Proyecto Gemelo Ceniza. Ahora ella también está atrapada en el bucle temporal.",
           // "Now that Solanum knows how time loop reset works, we will try reach the Vessel.": "Now that Solanum knows how time loop reset works, we will try reach the Vessel.",
           "Last cycle, Solanum was not sure how the time loop worked. This cycle it seems like she understood everything and now wants to go to the Vessel.": "Durante el último ciclo, Solanum no sabía cómo funcionaba el bucle temporal. Ahora lo tiene claro y quiere ir a La Nave.",
-  
-  
-          // Ernesto Quest        
+
+
+          // Ernesto Quest
           "Where is Ernesto?": "¿Dónde está Ernesto?",
           "Seriously, how could an anglerfish just disappear?": "En serio, ¿cómo puede haber desaparecido un rape?",
           "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Corné dice que el rape «Ernesto» ha desaparecido.",
@@ -221,6 +221,6 @@
           "I found Ernesto": "He encontrado a Ernesto",
           "I found Slate with Ernesto. He's cooking him on campfire.": "Encontré a Launa con Ernesto. Lo está cocinando.",
           "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Launa está cansado de malvaviscos, así que ha decidido cocinar a Ernesto. Dice que estará listo en 30 minutos. No necesito intervenir, ya que el bucle temporal se reiniciará antes de que eso pase."
-  
+
       }
   }


### PR DESCRIPTION
During test play I found a problem with some ship log titles displaying as untranslated.
The same problem was found in all languages except Russian, which I have fixed.