### PR TITLE
Fix "will probably will" in Giant's Deep Ship Log

### DIFF
--- a/planets/ShipLogs/GiantsDeep.xml
+++ b/planets/ShipLogs/GiantsDeep.xml
@@ -11,7 +11,7 @@
       <ID>SOLANUM_GD</ID>
       <SourceID>SOLANUM_TH</SourceID>
       <RumorName>Solanum on Giant's Deep</RumorName>
-      <Text>Solanum wants to visit Giant's Deep, but she will probably will stay on Timber Hearth as well.</Text>
+      <Text>Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.</Text>
     </RumorFact>
     <ExploreFact>
       <ID>SOLANUM_ON_GD</ID>

--- a/translations/french.json
+++ b/translations/french.json
@@ -144,7 +144,7 @@
 
         // Giants Deep
         "Solanum on Giant's Deep": "Solanum sur Léviathe",
-        "Solanum wants to visit Giant's Deep, but she probably will stay on Timber Hearth as well.": "Solanum veut visiter le Léviathe, mais elle restera probablement aussi à Âtrebois.",
+        "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "Solanum veut visiter le Léviathe, mais elle restera probablement aussi à Âtrebois.",
         "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "J'ai trouvé Solanum en train d'observer les journaux de bord de la sonde. Je n'ai jamais vu d'ordinateurs Nomaï avec une telle lueur verte. Elle accède à l'ordinateur principal pour savoir combien de temps s'est écoulé.",
         "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanum contemple l'Œil, et la vision qu'en ont les habitants de l'Étranger. Elle a aussi remarqué une Statue mnémonique qui fonctionne.",
 

--- a/translations/japanese.json
+++ b/translations/japanese.json
@@ -141,7 +141,7 @@
 
         // Giants Deep
         "Solanum on Giant's Deep": "巨人の大海のSolanum",
-        "Solanum wants to visit Giant's Deep, but she probably will stay on Timber Hearth as well.": "Solanumは巨人の大海に行きたいと言っているが、木の炉辺にもいるのだろう。",
+        "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "Solanumは巨人の大海に行きたいと言っているが、木の炉辺にもいるのだろう。",
         "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "Solanumが探査機のログを調べているところを見つけた。こんなに光り輝くNomaiのコンピューターは今まで見たことがない。彼女はメインコンピューターにアクセスし、どのくらいの時間が経過したのかを確認した。",
         "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Solanumは眼と流れ者の住人が見たビジョンについて考えている。彼女は記憶の像が起動していることに気づいた。",
 

--- a/translations/russian.json
+++ b/translations/russian.json
@@ -143,7 +143,7 @@
 
         // Giants Deep
         "Solanum on Giant's Deep": "Соланум на Пучине Гиганта",
-        "Solanum wants to visit Giant's Deep, but she probably will stay on Timber Hearth as well.": "Соланум хочет посетить Пучину Гиганта, но она скорее всего так же останется и на Камельке.",
+        "Solanum wants to visit Giant's Deep, but she will probably stay on Timber Hearth as well.": "Соланум хочет посетить Пучину Гиганта, но она скорее всего так же останется и на Камельке.",
         "I found Solanum observing the probe logs. I've never seen nomai computers with such a green glow. She's accessing the Main Computer to know how much time has passed.": "Я обнаружил Соланум, когда она проверяла данные модуля орбитального зонда. Я никогда не видел, чтобы компьютер Номаи светился зелёным цветом. Она запросила у главного компьютера дату последнего взаимодействия, чтобы понять сколько времени прошло.",
         "Solanum is contemplating the Eye, and the vision seen by the inhabitants of The Stranger. She also noticed a working Memory Statue.": "Соланум рассуждает об Оке Вселенной, а также о знаниях, которыми обладали обитатели Незнакомца. Её заинтересовала работающая статуя памяти.",
 


### PR DESCRIPTION
There is "will probably will" in `planets/ShipLogs/GiantsDeep.xml`.

It causes missing translation here in all languages:
![スクリーンショット (2603)](https://github.com/hearth1an/hearthian.TheVision/assets/17728957/fa40fe1c-8dad-4308-8de7-e3d6bc2f1ca8)

![スクリーンショット (2601)](https://github.com/hearth1an/hearthian.TheVision/assets/17728957/43a27d50-5144-4103-865a-20c6255e063f)

So, this PR fixes it.
Also, this PR fixes "probably will" -> "will probably" in some languages.