### PR TITLE
Fix typo in french translation

### DIFF
--- a/translations/french.json
+++ b/translations/french.json
@@ -196,7 +196,7 @@
         "Where is Ernesto?": "Où est Ernesto?",
         "Seriously, how could an anglerfish just disappear?": "Sérieusement, comment un coelacanthe peut-il disparaître ?",
         "Hornfels said that anglerfish «Ernesto» disappeared from exhibit.": "Cornée a déclaré que le coelacanthe \"Ernesto\" avait disparu de l'exposition.",
-        "Ernesto found": "Ernesto trouver",
+        "Ernesto found": "Ernesto trouvé",
         "I found Ernesto": "J'ai trouvé Ernesto",
         "I found Slate with Ernesto. He's cooking him on campfire.": "J'ai trouvé Ardoise avec Ernesto. Il le fait cuire sur le feu de camp.",
         "Slate is just fed up with marshmallow, that's why he decided to cook Ernesto. He said it will be ready in 30 minutes. Intervention isn't required because the loop will reset before that happens.": "Ardoise en a marre des guimauves, c'est pourquoi il a décidé de faire cuire Ernesto. Il a dit qu'il sera prêt dans 30 minutes. Aucune intervention n'est nécessaire car la boucle se réinitialisera avant que cela n'arrive."


### PR DESCRIPTION
There is a small typo on the french translations: the word is "trouver" instead of "trouvé". So I fixed that.